### PR TITLE
[VIP UART] Supports transmitting vectors with lowest index not at zero

### DIFF
--- a/bitvis_vip_uart/src/uart_bfm_pkg.vhd
+++ b/bitvis_vip_uart/src/uart_bfm_pkg.vhd
@@ -197,7 +197,7 @@ package body uart_bfm_pkg is
     tx <= not config.idle_state;
     wait for config.bit_time;
 
-    for j in 0 to config.num_data_bits-1 loop
+    for j in data_value'low to data_value'high loop
       tx <= data_value(j);
       wait for config.bit_time;
     end loop;


### PR DESCRIPTION
For instance trying to send data(15 downto 8) with uart_transmit will fail.
The length of the vector is compared against config.num_data_bits in line 192 and ends in a failure if they are different, so looping just the range should be fine.