### PR TITLE
Fix for updating v_num_data_bits when configuration changes

### DIFF
--- a/bitvis_vip_uart/src/uart_rx_vvc.vhd
+++ b/bitvis_vip_uart/src/uart_rx_vvc.vhd
@@ -249,6 +249,8 @@ begin
       -- update vvc activity
       update_vvc_activity_register(global_trigger_vvc_activity_register, vvc_status, ACTIVE, entry_num_in_vvc_activity_register, last_cmd_idx_executed, command_queue.is_empty(VOID), C_SCOPE);
 
+      v_num_data_bits := vvc_config.bfm_config.num_data_bits;
+
       -- Set the transaction info for waveview
       transaction_info           := C_TRANSACTION_INFO_DEFAULT;
       transaction_info.operation := v_cmd.operation;

--- a/bitvis_vip_uart/src/uart_tx_vvc.vhd
+++ b/bitvis_vip_uart/src/uart_tx_vvc.vhd
@@ -242,6 +242,8 @@ begin
       -- update vvc activity
       update_vvc_activity_register(global_trigger_vvc_activity_register, vvc_status, ACTIVE, entry_num_in_vvc_activity_register, last_cmd_idx_executed, command_queue.is_empty(VOID), C_SCOPE);
 
+      v_num_data_bits := vvc_config.bfm_config.num_data_bits;
+
       -- Set the transaction info for waveview
       transaction_info           := C_TRANSACTION_INFO_DEFAULT;
       transaction_info.operation := v_cmd.operation;


### PR DESCRIPTION
The value of the **v_num_data_bits** variable is not updated when the configuration of the VIP UART instance is changed.
This is already solved in **UVVM_3_BETA**. However, it would be good to integrate the fix into UVVM as well.

BR