### PR TITLE
Added functionality to add jitter to the clock generator

### DIFF
--- a/bitvis_vip_clock_generator/src/vvc_cmd_pkg.vhd
+++ b/bitvis_vip_clock_generator/src/vvc_cmd_pkg.vhd
@@ -47,7 +47,8 @@ package vvc_cmd_pkg is
     START_CLOCK,
     STOP_CLOCK,
     SET_CLOCK_PERIOD,
-    SET_CLOCK_HIGH_TIME
+    SET_CLOCK_HIGH_TIME,
+    SET_CLOCK_MAX_JITTER
   );
 
 
@@ -83,6 +84,7 @@ package vvc_cmd_pkg is
     -- VVC dedicated fields
     clock_period              : time;
     clock_high_time           : time;
+    clock_max_jitter          : time;
   end record;
 
   constant C_VVC_CMD_DEFAULT : t_vvc_cmd_record := (
@@ -102,7 +104,8 @@ package vvc_cmd_pkg is
     parent_msg_id_panel       => C_UNUSED_MSG_ID_PANEL,
     -- VVC dedicated fields
     clock_period              => 10 ns,
-    clock_high_time           => 5 ns
+    clock_high_time           => 5 ns,
+    clock_max_jitter          => 0 ns
   );
 
   --========================================================================================================================

--- a/bitvis_vip_clock_generator/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_clock_generator/src/vvc_methods_pkg.vhd
@@ -62,6 +62,7 @@ package vvc_methods_pkg is
     clock_name                            : string(1 to 30);
     clock_period                          : time;
     clock_high_time                       : time;
+    clock_max_jitter                      : time;
   end record;
 
   type t_vvc_config_array is array (natural range <>) of t_vvc_config;
@@ -78,7 +79,8 @@ package vvc_methods_pkg is
     msg_id_panel                          => C_VVC_MSG_ID_PANEL_DEFAULT,
     clock_name                            => ("Set clock name", others => NUL),
     clock_period                          => 10 ns,
-    clock_high_time                       => 5 ns
+    clock_high_time                       => 5 ns,
+    clock_max_jitter                      => 0 ns
   );
 
   type t_vvc_status is
@@ -164,6 +166,14 @@ package vvc_methods_pkg is
     constant scope              : in string := C_VVC_CMD_SCOPE_DEFAULT
   );
 
+  procedure set_clock_max_jitter(
+    signal   VVCT               : inout t_vvc_target_record;
+    constant vvc_instance_idx   : in integer;
+    constant clock_max_jitter   : in time;
+    constant msg                : in string;
+    constant scope              : in string := C_VVC_CMD_SCOPE_DEFAULT
+  );
+
 
   --==============================================================================
   -- VVC Activity
@@ -245,6 +255,22 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.clock_high_time := clock_high_time;
     send_command_to_vvc(VVCT, scope => scope);
   end procedure set_clock_high_time;
+
+  procedure set_clock_max_jitter(
+    signal   VVCT               : inout t_vvc_target_record;
+    constant vvc_instance_idx   : in integer;
+    constant clock_max_jitter   : in time;
+    constant msg                : in string;
+    constant scope              : in string := C_VVC_CMD_SCOPE_DEFAULT
+  ) is
+    constant proc_name : string := "set_clock_max_jitter";
+    constant proc_call : string := proc_name & "(" & to_string(VVCT, vvc_instance_idx)  -- First part common for all
+             & ")";
+  begin
+    set_general_target_and_command_fields(VVCT, vvc_instance_idx, proc_call, msg, QUEUED, SET_CLOCK_MAX_JITTER);
+    shared_vvc_cmd.clock_max_jitter := clock_max_jitter;
+    send_command_to_vvc(VVCT, scope => scope);
+  end procedure set_clock_max_jitter;
 
 
   --==============================================================================


### PR DESCRIPTION
Here is the implementation of jitter I did in 2021.

The implementation is based on the code found at the tag v2021.05.26

I have not looked into making an updated version that could merge onto master. But if the functionality is wanted, and the implementation looks good, then I can consider taking some time to look into it.