### PR TITLE
Fixed bug in await_change_to_value for std_logic_vector

### DIFF
--- a/uvvm_util/src/methods_pkg.vhd
+++ b/uvvm_util/src/methods_pkg.vhd
@@ -8358,7 +8358,7 @@ package body methods_pkg is
     variable v_match             : boolean := false;
   begin
     while (now - C_START_TIME) < min_time loop
-      wait on target for min_time;
+      wait on target for min_time - (now - C_START_TIME);
       v_match             := check_value(target, exp_value, match_strictness, NO_ALERT, "check_value within: " & C_NAME, scope);
       v_no_alert_min_time := not (target'event and v_match); -- false (alert) if change to exp_value occurred before min_time
       exit when (target'event and (target = exp_value));


### PR DESCRIPTION
Change to an unexpected value before the expected value (within the expected time range) can lead to false detection of an too early change.

Please refer to this [patch against UVVM_SUPPLEMENTARY](https://github.com/user-attachments/files/23649052/Extended_await_change_to_value_for_std_logic_vector.patch) for an extension for the maintenance testbench that shows this error.
