### PR TITLE
Functional coverage cross check across entire transition chain

### DIFF
--- a/uvvm_util/src/func_cov_pkg.vhd
+++ b/uvvm_util/src/func_cov_pkg.vhd
@@ -3320,14 +3320,17 @@ package body func_cov_pkg is
       constant values        : in integer_vector;
       constant msg_id_panel  : in t_msg_id_panel := shared_msg_id_panel;
       constant ext_proc_call : in string         := "") is
-      constant C_LOCAL_CALL        : string                                           := "sample_coverage(" & to_string(values) & ")";
-      variable v_proc_call         : line;
-      variable v_invalid_sample    : boolean                                          := false;
-      variable v_value_match       : std_logic_vector(0 to priv_num_bins_crossed - 1) := (others => '0');
-      variable v_illegal_match_idx : integer                                          := -1;
-      variable v_num_occurrences   : natural                                          := 0;
-      variable v_sample_shift_reg  : t_integer_vector_ptr;
-      variable v_bin_values        : t_integer_vector_ptr;
+      constant C_LOCAL_CALL         : string                                           := "sample_coverage(" & to_string(values) & ")";
+      variable v_proc_call          : line;
+      variable v_invalid_sample     : boolean                                          := false;
+      variable v_value_match        : std_logic_vector(0 to priv_num_bins_crossed - 1) := (others => '0');
+      variable v_illegal_match_idx  : integer                                          := -1;
+      variable v_num_occurrences    : natural                                          := 0;
+      variable v_sample_shift_reg   : t_integer_vector_ptr;
+      variable v_bin_values         : t_integer_vector_ptr;
+      variable v_bins_contains_tran : boolean := false;
+      variable v_num_of_transitions : integer := 0;
+      variable v_all_values_match   : boolean := false;
     begin
       create_proc_call(C_LOCAL_CALL, ext_proc_call, v_proc_call);
       if priv_num_bins_crossed = C_UNINITIALIZED then
@@ -3351,19 +3354,74 @@ package body func_cov_pkg is
       -- Check if the values should be ignored or are illegal
       for i in 0 to priv_invalid_bins_idx - 1 loop
         priv_invalid_bins(i).transition_mask := priv_invalid_bins(i).transition_mask(priv_invalid_bins(i).transition_mask'length - 2 downto 0) & '1';
+        v_bins_contains_tran := false;
         for j in 0 to priv_num_bins_crossed - 1 loop
+          -- check if cross contains transitions, if that is the case we need to comprare value/range matches across entire transition
+          for m in 0 to priv_num_bins_crossed - 1 loop
+            case priv_invalid_bins(i).cross_bins(m).contains is
+              when TRN | TRN_IGNORE | TRN_ILLEGAL =>
+                v_num_of_transitions := priv_invalid_bins(i).cross_bins(m).num_values - 1;
+                v_bins_contains_tran := true;
+              when others =>
+                null;
+            end case;
+          end loop;
+
           case priv_invalid_bins(i).cross_bins(j).contains is
             when VAL | VAL_IGNORE | VAL_ILLEGAL =>
-              for k in 0 to priv_invalid_bins(i).cross_bins(j).num_values - 1 loop
-                if values(j) = priv_invalid_bins(i).cross_bins(j).values(k) then
+            for k in 0 to priv_invalid_bins(i).cross_bins(j).num_values - 1 loop
+              if values(j) = priv_invalid_bins(i).cross_bins(j).values(k) then
+                if v_bins_contains_tran then
+                  -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.
+                  v_sample_shift_reg     := new integer_vector(v_num_of_transitions downto 0);
+                  v_sample_shift_reg.all := priv_bin_sample_shift_reg(j)(v_num_of_transitions downto 0);
+
+                  -- Check if there are enough valid values in the shift register to compare the transition
+                  if priv_invalid_bins(i).transition_mask(v_num_of_transitions) = '1' then
+                    for l in v_sample_shift_reg.all'range loop
+                      if v_sample_shift_reg.all(l) = priv_invalid_bins(i).cross_bins(j).values(k) then
+                        v_all_values_match := true;
+                      else
+                        v_all_values_match := false;
+                        exit;
+                      end if;
+                    end loop;
+                    if v_all_values_match then
+                      v_value_match(j)    := '1';
+                      v_illegal_match_idx := j when priv_invalid_bins(i).cross_bins(j).contains = VAL_ILLEGAL;
+                    end if;
+                  end if;
+                else
                   v_value_match(j)    := '1';
                   v_illegal_match_idx := j when priv_invalid_bins(i).cross_bins(j).contains = VAL_ILLEGAL;
+                end if;
                 end if;
               end loop;
             when RAN | RAN_IGNORE | RAN_ILLEGAL =>
               if values(j) >= priv_invalid_bins(i).cross_bins(j).values(0) and values(j) <= priv_invalid_bins(i).cross_bins(j).values(1) then
-                v_value_match(j)    := '1';
-                v_illegal_match_idx := j when priv_invalid_bins(i).cross_bins(j).contains = RAN_ILLEGAL;
+                if v_bins_contains_tran then
+                  -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.
+                  v_sample_shift_reg     := new integer_vector(v_num_of_transitions downto 0);
+                  v_sample_shift_reg.all := priv_bin_sample_shift_reg(j)(v_num_of_transitions downto 0);
+                  -- Check if there are enough valid values in the shift register to compare the transition
+                  if priv_invalid_bins(i).transition_mask(v_num_of_transitions) = '1' then
+                    for l in v_sample_shift_reg.all'range loop
+                      if v_sample_shift_reg.all(l) >= priv_invalid_bins(i).cross_bins(j).values(0) and v_sample_shift_reg.all(l) <= priv_invalid_bins(i).cross_bins(j).values(1) then
+                        v_all_values_match := true;
+                      else
+                        v_all_values_match := false;
+                        exit;
+                      end if;
+                    end loop;
+                    if v_all_values_match then
+                      v_value_match(j)    := '1';
+                      v_illegal_match_idx := j when priv_invalid_bins(i).cross_bins(j).contains = RAN_ILLEGAL;
+                    end if;
+                  end if;
+                else
+                  v_value_match(j)    := '1';
+                  v_illegal_match_idx := j when priv_invalid_bins(i).cross_bins(j).contains = RAN_ILLEGAL;
+                end if;
               end if;
             when TRN | TRN_IGNORE | TRN_ILLEGAL =>
               -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.
@@ -3399,17 +3457,69 @@ package body func_cov_pkg is
       if not (v_invalid_sample) then
         for i in 0 to priv_bins_idx - 1 loop
           priv_bins(i).transition_mask := priv_bins(i).transition_mask(priv_bins(i).transition_mask'length - 2 downto 0) & '1';
+          v_bins_contains_tran := false;
           for j in 0 to priv_num_bins_crossed - 1 loop
+            -- check if cross contains transitions, if that is the case we need to comprare value/range matches across entire transition
+            for m in 0 to priv_num_bins_crossed - 1 loop
+              case priv_bins(i).cross_bins(m).contains is
+                when TRN =>
+                  v_num_of_transitions := priv_bins(i).cross_bins(m).num_values - 1;
+                  v_bins_contains_tran := true;
+                when others =>
+                  null;
+              end case;
+            end loop;
+
             case priv_bins(i).cross_bins(j).contains is
               when VAL =>
-                for k in 0 to priv_bins(i).cross_bins(j).num_values - 1 loop
-                  if values(j) = priv_bins(i).cross_bins(j).values(k) then
-                    v_value_match(j) := '1';
+              for k in 0 to priv_bins(i).cross_bins(j).num_values - 1 loop
+                if values(j) = priv_bins(i).cross_bins(j).values(k) then
+                    if v_bins_contains_tran then
+                      -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.
+                      v_sample_shift_reg     := new integer_vector(v_num_of_transitions downto 0);
+                      v_sample_shift_reg.all := priv_bin_sample_shift_reg(j)(v_num_of_transitions downto 0);
+                      -- Check if there are enough valid values in the shift register to compare the transition
+                      if priv_bins(i).transition_mask(v_num_of_transitions) = '1' then
+                        for l in v_sample_shift_reg.all'range loop
+                          if v_sample_shift_reg.all(l) = priv_bins(i).cross_bins(j).values(k) then
+                            v_all_values_match := true;
+                          else
+                            v_all_values_match := false;
+                            exit;
+                          end if;
+                        end loop;
+                        if v_all_values_match then
+                          v_value_match(j)    := '1';
+                        end if;
+                      end if;
+                    else
+                      v_value_match(j) := '1';
+                    end if;
                   end if;
                 end loop;
               when RAN =>
-                if values(j) >= priv_bins(i).cross_bins(j).values(0) and values(j) <= priv_bins(i).cross_bins(j).values(1) then
-                  v_value_match(j) := '1';
+              if values(j) >= priv_bins(i).cross_bins(j).values(0) and values(j) <= priv_bins(i).cross_bins(j).values(1) then
+                  if v_bins_contains_tran then
+                    -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.
+                    v_sample_shift_reg     := new integer_vector(v_num_of_transitions downto 0);
+                    v_sample_shift_reg.all := priv_bin_sample_shift_reg(j)(v_num_of_transitions downto 0);
+                    -- Check if there are enough valid values in the shift register to compare the transition
+                    if priv_bins(i).transition_mask(priv_bins(i).cross_bins(j).num_values - 1) = '1' then
+                      for l in v_sample_shift_reg.all'range loop
+                        if v_sample_shift_reg.all(l) >= priv_bins(i).cross_bins(j).values(0) and v_sample_shift_reg.all(l) <= priv_bins(i).cross_bins(j).values(1) then
+                          v_all_values_match := true;
+                        else
+                          v_all_values_match := false;
+                          exit;
+                        end if;
+                      end loop;
+                      if v_all_values_match then
+                        v_value_match(j)    := '1';
+                      end if;
+                    end if;
+                  else
+                    v_value_match(j) := '1';
+                  end if;
                 end if;
               when TRN =>
                 -- Fix for Modelsim: copy the 2 values to variables before comparing them, otherwise the comparison always returns true.

--- a/uvvm_util/tb/maintenance_tb/func_cov_tb.vhd
+++ b/uvvm_util/tb/maintenance_tb/func_cov_tb.vhd
@@ -1580,14 +1580,14 @@ begin
       check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7003, 7020), (7100, 7102, 7104), hits => 1, name => "transition_8");
       check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7003, 7030), (7100, 7102, 7104), hits => 1, name => "transition_9");
       check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7004, 7010), (7100, 7102, 7104), hits => 1, name => "transition_10");
-      check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7004, 7020), (7100, 7102, 7104), hits => 0, name => "transition_11");
+      check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7004, 7020), (7100, 7102, 7104), hits => 1, name => "transition_11");
       check_cross_bin(v_cross_x2, v_bin_idx, (TRN, TRN), (7000, 7004, 7030), (7100, 7102, 7104), hits => 1, name => "transition_12");
       check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, TRN_IGNORE), (7000, 7001, 7010), (7100, 7102, 7104), hits => 1, name => "ignore_transition_1");
       check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, TRN_IGNORE), (7000, 7001, 7020), (7100, 7102, 7105), hits => 0, name => "ignore_transition_2");
       check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, TRN_IGNORE), (7000, 7002), (7100, 7102), hits => 3, name => "ignore_transition_3");
       check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, TRN_IGNORE), (7003, 7010), (7102, 7104), hits => 1, name => "ignore_transition_4");
       check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, VAL), (7000, 7004, 7010), (0 => 7100), hits => 0, name => "ignore_transition_5");
-      check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, VAL), (7000, 7004, 7020), (0 => 7104), hits => 1, name => "ignore_transition_6");
+      check_invalid_cross_bin(v_cross_x2, v_invalid_bin_idx, (TRN_IGNORE, VAL), (7000, 7004, 7020), (0 => 7104), hits => 0, name => "ignore_transition_6");
 
       delete_coverpoint(v_cross_x2);
 


### PR DESCRIPTION
## Problem:

I am confident I found a bug in the current implementation of cross in functional coverage. Right now, in functional coverage, if you make a cross:
```
my_covp.add_cross(bin_range(2,3), bin_transition(1,2,3), bin_range(2,3), "my cross");
```
The cross will get a hit if the non-transition bins get a hit at the same time as the transition bin gets a hit. This makes sense as I would assume a cross only does `HIT? = HIT_A and HIT_B and HIT_C`, but since a transition checks across multiple samples, I would assume a cross *should* also compare the hits from a non-transition bin over the entire transition. **Example:**
```
[sample: 0] (1,1,1) -> NO, HIT-partial, NO
[sample: 1] (2,2,2) -> HIT, HIT-partial, HIT
[sample: 2] (3,3,3) -> HIT, HIT, HIT (cross get a HIT, which I believe is a mistake)
...
[sample: 0] (2,1,2) -> HIT, HIT-partial, HIT
[sample: 1] (2,2,2) -> HIT, HIT-partial, HIT
[sample: 2] (3,3,3) -> HIT, HIT, HIT (cross get a HIT, and all non-transition bin(s) were HIT during the entire transition chain, which I believe is the only case a cross with a/multiple transition bin(s) should get a HIT)
```

## Solution:

Luckily, solving this is not a hard fix. Inside the `sample_coverage()` procedure of `func_cov_pkg.vhd` all bins in a cross have a shift register of previous values, which we can use to compare across a transition chain. I've added a loop at the start of a cross check which will toggle a variable `v_bins_contains_tran` if there are any transition bin(s) in the cross, and then I've added a check across the entire transition chain matching the check used for a transition bin. [see line 3359:3368 & 3465:3473]

I have run this solution on a minimal case TB using many different combinations of crosses, and am confident this does not break any previous usage (except if you use crosses with transitions and expect the non-transitions to only be checked on the last transition).