### PR TITLE
Added configuration for bit order in spi bfm

### DIFF
--- a/bitvis_vip_spi/src/spi_bfm_pkg.vhd
+++ b/bitvis_vip_spi/src/spi_bfm_pkg.vhd
@@ -53,7 +53,6 @@ package spi_bfm_pkg is
     id_for_bfm               : t_msg_id;           -- The message ID used as a general message ID in the SPI BFM
     id_for_bfm_wait          : t_msg_id;           -- DEPRECATED: will be removed in v3
     id_for_bfm_poll          : t_msg_id;           -- DEPRECATED: will be removed in v3
-    bit_order                : t_bit_order;         -- Bit shift order: MSB_FIRST (default) or LSB_FIRST
   end record;
 
   constant C_SPI_BFM_CONFIG_DEFAULT : t_spi_bfm_config := (
@@ -66,8 +65,7 @@ package spi_bfm_pkg is
     match_strictness       => MATCH_EXACT,
     id_for_bfm             => ID_BFM,
     id_for_bfm_wait        => ID_BFM_WAIT,
-    id_for_bfm_poll        => ID_BFM_POLL,
-    bit_order              => MSB_FIRST
+    id_for_bfm_poll        => ID_BFM_POLL
   );
 
   -- Dummy signal to pass in procedure sub-calls in spi_slave method overloads without terminate_access parameter
@@ -113,6 +111,7 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -131,6 +130,7 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -145,6 +145,7 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -162,7 +163,8 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   -- Multi-word
@@ -176,7 +178,8 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   ------------------------------------------
@@ -191,7 +194,8 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   -- Multi-word
@@ -203,7 +207,8 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   ------------------------------------------
@@ -218,7 +223,8 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   -- Multi-word
@@ -230,7 +236,8 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   ------------------------------------------
@@ -249,7 +256,8 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   -- Multi-word
@@ -262,7 +270,8 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   );
 
   ------------------------------------------
@@ -285,6 +294,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -302,6 +312,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -318,6 +329,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -333,6 +345,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -347,6 +360,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -360,6 +374,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -376,6 +391,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -390,6 +406,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -403,6 +420,7 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -421,7 +439,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload without terminate_access
@@ -434,7 +453,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word
@@ -448,7 +468,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word without terminate_access
@@ -461,7 +482,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   ------------------------------------------
@@ -478,7 +500,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload with terminate_access without aborted
@@ -490,7 +513,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload without terminate_access and without aborted
@@ -501,7 +525,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word
@@ -513,7 +538,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word without terminate_access
@@ -524,7 +550,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   ------------------------------------------
@@ -541,7 +568,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload with terminate_access and without aborted
@@ -553,7 +581,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload without terminate_access and without aborted
@@ -564,7 +593,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word
@@ -576,7 +606,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word without terminate_access
@@ -587,7 +618,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   ------------------------------------------
@@ -607,7 +639,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Overload without terminate_access
@@ -619,7 +652,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word
@@ -632,7 +666,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
   -- Multi-word without terminate_access
@@ -644,7 +679,8 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST
   );
 
 end package spi_bfm_pkg;
@@ -734,6 +770,7 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     constant C_LOCAL_PROC_NAME                 : string                                        := "spi_master_transmit_and_receive";
@@ -772,7 +809,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' then
       -- set MOSI together with SS_N when CPHA=0
       if not config.CPHA then
-        mosi       <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+        mosi       <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -789,15 +826,15 @@ package body spi_bfm_pkg is
       while ss_n = '0' and not v_access_done loop
 
         if not config.CPHA then
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
         else                            -- config.CPHA
-          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
         end if;
 
         if v_tx_count < C_ACCESS_SIZE - 1 then -- Not done
@@ -810,7 +847,7 @@ package body spi_bfm_pkg is
             v_rx_count                            := v_rx_count + 1;
             -- Sample Last bit on the second to last edge of SCLK (CPOL=0: last rising. CPOL=1: last falling)
             wait for config.spi_bit_time / 2;
-            v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
+            v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
             sclk                                  <= not config.CPOL;
           end if;
           log(config.id_for_bfm, v_proc_call.all & "=> " & to_string(v_tx_data, HEX, SKIP_LEADING_0, INCL_RADIX) & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
@@ -865,12 +902,13 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_master_transmit_and_receive(tx_data, rx_data, msg,
                                     spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso,
-                                    action_when_transfer_is_done, scope, msg_id_panel, config, ext_proc_call);
+                                    action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Multi-word
@@ -884,6 +922,7 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
@@ -909,7 +948,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit_and_receive(tx_data(idx), rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, ext_proc_call);
+      spi_master_transmit_and_receive(tx_data(idx), rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, ext_proc_call);
     end loop;
   end procedure;
 
@@ -925,7 +964,8 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string  := "spi_master_transmit_and_check";
     constant C_LOCAL_PROC_CALL : string  := C_LOCAL_PROC_NAME;
@@ -934,7 +974,7 @@ package body spi_bfm_pkg is
     variable v_check_ok      : boolean := true;
     variable v_alert_radix   : t_radix;
   begin
-    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
 
     for i in data_exp'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
@@ -966,7 +1006,8 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME              : string := "spi_master_transmit_and_check";
     constant C_LOCAL_PROC_CALL              : string := C_LOCAL_PROC_NAME;
@@ -993,7 +1034,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config);
+      spi_master_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
     end loop;
   end procedure;
 
@@ -1007,14 +1048,15 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_master_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME;
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0);
   begin
-    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -1026,7 +1068,8 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1046,7 +1089,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit(tx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config);
+      spi_master_transmit(tx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
     end loop;
   end procedure;
 
@@ -1060,14 +1103,15 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                        := "spi_master_receive";
     constant C_LOCAL_PROC_CALL : string                                        := C_LOCAL_PROC_NAME;
     -- Helper variables
     variable v_tx_data       : std_logic_vector(rx_data'length - 1 downto 0) := (others => '0');
   begin
-    spi_master_transmit_and_receive(v_tx_data, rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(v_tx_data, rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -1079,7 +1123,8 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1099,7 +1144,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_receive(rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config);
+      spi_master_receive(rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
     end loop;
   end procedure;
 
@@ -1114,7 +1159,8 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                         := "spi_master_check";
     constant C_LOCAL_PROC_CALL : string                                         := C_LOCAL_PROC_NAME;
@@ -1124,7 +1170,7 @@ package body spi_bfm_pkg is
     variable v_check_ok      : boolean                                        := true;
     variable v_alert_radix   : t_radix;
   begin
-    spi_master_transmit_and_receive(v_tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(v_tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
 
     for i in data_exp'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
@@ -1155,7 +1201,8 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1175,7 +1222,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_check(data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config);
+      spi_master_check(data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
     end loop;
   end procedure;
 
@@ -1198,6 +1245,7 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     -- Local_proc_name/call used if called from sequencer or VVC
@@ -1253,7 +1301,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' and not v_terminated then
       -- set MISO together with SS_N when CPHA=0
       if not config.CPHA then
-        miso       <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+        miso       <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -1275,13 +1323,13 @@ package body spi_bfm_pkg is
       while (ss_n = '0') and not(v_access_done) and not(v_terminated) loop
 
         if not config.CPHA then
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
         else                            -- config.CPHA
-          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
+          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
         end if;
 
         if terminate_access = '1' then
@@ -1322,7 +1370,7 @@ package body spi_bfm_pkg is
     -- Sample last bit
     if (config.CPHA = '0') and not (v_terminated) then
       v_rx_count                            := v_rx_count + 1;
-      v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
+      v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
       wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1')  or (ss_n = '1');
     end if;
 
@@ -1377,12 +1425,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                   sclk, ss_n, mosi, miso, terminate_access, ERROR, when_to_start_transfer, scope,
-                                  msg_id_panel, config, ext_proc_call);
+                                  msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1398,12 +1447,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                   sclk, ss_n, mosi, miso, no_access_termination, ERROR, when_to_start_transfer, scope,
-                                  msg_id_panel, config, ext_proc_call);
+                                  msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   procedure spi_slave_transmit_and_receive(
@@ -1418,12 +1468,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, terminate_access,
-                                   NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
+                                   NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Overload with terminate_access without aborted
@@ -1437,12 +1488,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, terminate_access, ERROR,
-                                   when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
+                                   when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1455,12 +1507,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, no_access_termination, ERROR,
-                                   when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
+                                   when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Multi-word
@@ -1476,6 +1529,7 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
@@ -1485,7 +1539,7 @@ package body spi_bfm_pkg is
     end if;
     for idx in 0 to (tx_data'length - 1) loop
       exit when (terminate_access = '1');
-      spi_slave_transmit_and_receive(tx_data(idx), rx_data(idx), aborted, msg, spi_if, terminate_access, aborted_alert_level, when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
+      spi_slave_transmit_and_receive(tx_data(idx), rx_data(idx), aborted, msg, spi_if, terminate_access, aborted_alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
       exit when (aborted = True);
     end loop;
   end procedure;
@@ -1501,12 +1555,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg, spi_if,
                                 terminate_access, ERROR, when_to_start_transfer,
-                                scope, msg_id_panel, config, ext_proc_call);
+                                scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   -- Multi-word without terminate_access and without aborted
@@ -1519,12 +1574,13 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg, spi_if,
                                 no_access_termination, ERROR, when_to_start_transfer,
-                                scope, msg_id_panel, config, ext_proc_call);
+                                scope, msg_id_panel, config, bit_order, ext_proc_call);
   end procedure;
 
   ------------------------------------------
@@ -1540,7 +1596,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string  := "spi_slave_transmit_and_check";
     constant C_LOCAL_PROC_CALL : string  := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1550,7 +1607,7 @@ package body spi_bfm_pkg is
     variable v_aborted       : boolean := false;
     variable v_alert_radix   : t_radix;
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
 
     if terminate_access = '0' then
       for i in data_exp'range loop
@@ -1587,12 +1644,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_transmit_and_check(tx_data, data_exp, msg,
                                 spi_if, no_access_termination, alert_level,
-                                when_to_start_transfer, scope, msg_id_panel, config);
+                                when_to_start_transfer, scope, msg_id_panel, config, bit_order);
   end procedure;
 
   -- Multi-word
@@ -1606,7 +1664,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_CALL : string := "spi_slave_transmit_and_check"; -- External proc_call; overwrite if called from other BFM procedure like spi_*_check
   begin
@@ -1617,7 +1676,7 @@ package body spi_bfm_pkg is
     for idx in 0 to (tx_data'length - 1) loop
       exit when (terminate_access = '1');
       -- call single-word procedure - will handle error checking
-      spi_slave_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config);
+      spi_slave_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order);
     end loop;
 
     if terminate_access = '1' then
@@ -1635,12 +1694,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_transmit_and_check(tx_data, data_exp, msg,
                                 spi_if, no_access_termination, alert_level,
-                                when_to_start_transfer, scope, msg_id_panel, config);
+                                when_to_start_transfer, scope, msg_id_panel, config, bit_order);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1655,14 +1715,15 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0); -- := (others => '0');
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload with terminate_access and without aborted
@@ -1674,14 +1735,15 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0); -- := (others => '0');
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_no_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_no_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload without terminate_access without aborted
@@ -1692,12 +1754,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_transmit(tx_data, v_no_aborted, msg, spi_if,
                       no_access_termination, when_to_start_transfer,
-                      scope, msg_id_panel, config);
+                      scope, msg_id_panel, config, bit_order);
   end procedure;
 
   -- Multi-word
@@ -1709,7 +1772,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                                                   := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string                                                                   := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1717,7 +1781,7 @@ package body spi_bfm_pkg is
     variable v_tx_data       : t_slv_array(tx_data'length - 1 downto 0)(tx_data(0)'length - 1 downto 0) := (others => (others => '0'));
   begin
     -- call multi-word procedure
-    spi_slave_transmit_and_receive(tx_data, v_tx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_tx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word without terminate_access
@@ -1728,12 +1792,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_transmit(tx_data, msg, spi_if,
                       no_access_termination, when_to_start_transfer,
-                      scope, msg_id_panel, config);
+                      scope, msg_id_panel, config, bit_order);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1748,14 +1813,15 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                        := "spi_slave_receive";
     constant C_LOCAL_PROC_CALL : string                                        := C_LOCAL_PROC_NAME & "(" & to_string(rx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_tx_data       : std_logic_vector(rx_data'length - 1 downto 0) := (others => '0');
   begin
-    spi_slave_transmit_and_receive(v_tx_data, rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_tx_data, rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload with terminate_access and without aborted
@@ -1767,12 +1833,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_receive(rx_data, v_no_aborted, msg, spi_if,
                     terminate_access, when_to_start_transfer,
-                    scope, msg_id_panel, config);
+                    scope, msg_id_panel, config, bit_order);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1783,12 +1850,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_receive(rx_data, v_no_aborted, msg, spi_if,
                     no_access_termination, when_to_start_transfer,
-                    scope, msg_id_panel, config);
+                    scope, msg_id_panel, config, bit_order);
   end procedure;
 
   -- Multi-word
@@ -1800,7 +1868,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                                                   := "spi_slave_receive";
     constant C_LOCAL_PROC_CALL : string                                                                   := C_LOCAL_PROC_NAME & "(" & to_string(rx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1808,7 +1877,7 @@ package body spi_bfm_pkg is
     variable v_rx_data       : t_slv_array(rx_data'length - 1 downto 0)(rx_data(0)'length - 1 downto 0) := (others => (others => '0'));
   begin
     -- call multi-word procedure
-    spi_slave_transmit_and_receive(v_rx_data, rx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_rx_data, rx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word without terminate_access
@@ -1819,12 +1888,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_receive(rx_data, msg, spi_if,
                     no_access_termination, when_to_start_transfer,
-                    scope, msg_id_panel, config);
+                    scope, msg_id_panel, config, bit_order);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1839,7 +1909,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string                                         := "spi_slave_check";
     constant C_LOCAL_PROC_CALL : string                                         := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1850,7 +1921,7 @@ package body spi_bfm_pkg is
     variable v_alert_radix   : t_radix;
     variable v_aborted       : boolean := false;
   begin
-    spi_slave_transmit_and_receive(v_tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
 
     if terminate_access = '0' then
 
@@ -1887,12 +1958,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_check(data_exp, msg, spi_if,
                   no_access_termination, alert_level, when_to_start_transfer,
-                  scope, msg_id_panel, config);
+                  scope, msg_id_panel, config, bit_order);
   end procedure;
 
   -- Multi-word
@@ -1905,7 +1977,8 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_check";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1913,7 +1986,7 @@ package body spi_bfm_pkg is
     for idx in 0 to (data_exp'length - 1) loop
       exit when (terminate_access = '1');
       -- call singl-word procedure - will handle error check
-      spi_slave_check(data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config);
+      spi_slave_check(data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order);
     end loop;
 
     if terminate_access = '1' then
@@ -1930,12 +2003,13 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST
   ) is
   begin
     spi_slave_check(data_exp, msg, spi_if,
                   no_access_termination, alert_level, when_to_start_transfer,
-                  scope, msg_id_panel, config);
+                  scope, msg_id_panel, config, bit_order);
   end procedure;
 
 end package body spi_bfm_pkg;

--- a/bitvis_vip_spi/src/spi_bfm_pkg.vhd
+++ b/bitvis_vip_spi/src/spi_bfm_pkg.vhd
@@ -32,6 +32,8 @@ package spi_bfm_pkg is
   --===============================================================================================
   constant C_BFM_SCOPE : string := "SPI BFM";
 
+  type t_bit_order is (MSB_FIRST, LSB_FIRST);
+
   type t_spi_if is record
     ss_n : std_logic;                   -- master to slave
     sclk : std_logic;                   -- master to slave
@@ -51,6 +53,7 @@ package spi_bfm_pkg is
     id_for_bfm               : t_msg_id;           -- The message ID used as a general message ID in the SPI BFM
     id_for_bfm_wait          : t_msg_id;           -- DEPRECATED: will be removed in v3
     id_for_bfm_poll          : t_msg_id;           -- DEPRECATED: will be removed in v3
+    bit_order                : t_bit_order;         -- Bit shift order: MSB_FIRST (default) or LSB_FIRST
   end record;
 
   constant C_SPI_BFM_CONFIG_DEFAULT : t_spi_bfm_config := (
@@ -63,7 +66,8 @@ package spi_bfm_pkg is
     match_strictness       => MATCH_EXACT,
     id_for_bfm             => ID_BFM,
     id_for_bfm_wait        => ID_BFM_WAIT,
-    id_for_bfm_poll        => ID_BFM_POLL
+    id_for_bfm_poll        => ID_BFM_POLL,
+    bit_order              => MSB_FIRST
   );
 
   -- Dummy signal to pass in procedure sub-calls in spi_slave method overloads without terminate_access parameter
@@ -651,6 +655,40 @@ end package spi_bfm_pkg;
 package body spi_bfm_pkg is
 
   ---------------------------------------------------------------------------------
+  -- Returns correct indexing in tx_data vector based on bit order configuration
+  ---------------------------------------------------------------------------------
+
+  function tx_bit_idx(
+    constant count : in integer;
+    constant size  : in integer;
+    constant order : in t_bit_order
+  ) return integer is
+  begin
+    if order = MSB_FIRST then
+      return size - count - 1;
+    else -- LSB_FIRST
+      return count;
+    end if;
+  end function;
+
+  ---------------------------------------------------------------------------------
+  -- Returns correct indexing in rx_data vector based on bit order configuration
+  ---------------------------------------------------------------------------------
+
+  function rx_bit_idx(
+    constant count : in integer;
+    constant size  : in integer;
+    constant order : in t_bit_order
+  ) return integer is
+  begin
+    if order = MSB_FIRST then
+      return size - count;
+    else -- LSB_FIRST
+      return count - 1;
+    end if;
+  end function;
+
+  ---------------------------------------------------------------------------------
   -- initialize spi to dut signals
   ---------------------------------------------------------------------------------
 
@@ -734,7 +772,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' then
       -- set MOSI together with SS_N when CPHA=0
       if not config.CPHA then
-        mosi       <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+        mosi       <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -751,15 +789,15 @@ package body spi_bfm_pkg is
       while ss_n = '0' and not v_access_done loop
 
         if not config.CPHA then
-          v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          mosi                                  <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
         else                            -- config.CPHA
-          mosi                                  <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
         end if;
 
         if v_tx_count < C_ACCESS_SIZE - 1 then -- Not done
@@ -772,7 +810,7 @@ package body spi_bfm_pkg is
             v_rx_count                            := v_rx_count + 1;
             -- Sample Last bit on the second to last edge of SCLK (CPOL=0: last rising. CPOL=1: last falling)
             wait for config.spi_bit_time / 2;
-            v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
+            v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := miso;
             sclk                                  <= not config.CPOL;
           end if;
           log(config.id_for_bfm, v_proc_call.all & "=> " & to_string(v_tx_data, HEX, SKIP_LEADING_0, INCL_RADIX) & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
@@ -1215,7 +1253,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' and not v_terminated then
       -- set MISO together with SS_N when CPHA=0
       if not config.CPHA then
-        miso       <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+        miso       <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -1237,13 +1275,13 @@ package body spi_bfm_pkg is
       while (ss_n = '0') and not(v_access_done) and not(v_terminated) loop
 
         if not config.CPHA then
-          v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          miso                                  <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
         else                            -- config.CPHA
-          miso                                  <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
+          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, config.bit_order));
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
+          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
         end if;
 
         if terminate_access = '1' then
@@ -1284,7 +1322,7 @@ package body spi_bfm_pkg is
     -- Sample last bit
     if (config.CPHA = '0') and not (v_terminated) then
       v_rx_count                            := v_rx_count + 1;
-      v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
+      v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, config.bit_order)) := mosi;
       wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1')  or (ss_n = '1');
     end if;
 

--- a/bitvis_vip_spi/src/spi_vvc.vhd
+++ b/bitvis_vip_spi/src/spi_vvc.vhd
@@ -304,7 +304,8 @@ begin
                                               action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                               scope                        => C_SCOPE,
                                               msg_id_panel                 => v_msg_id_panel,
-                                              config                       => vvc_config.bfm_config);
+                                              config                       => vvc_config.bfm_config,
+                                              bit_order                    => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -316,7 +317,8 @@ begin
                                               action_between_words         => v_cmd.action_between_words,
                                               scope                        => C_SCOPE,
                                               msg_id_panel                 => v_msg_id_panel,
-                                              config                       => vvc_config.bfm_config);
+                                              config                       => vvc_config.bfm_config,
+                                              bit_order                    => v_cmd.bit_order);
               v_result          := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
 
@@ -354,7 +356,8 @@ begin
                                             action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                             scope                        => C_SCOPE,
                                             msg_id_panel                 => v_msg_id_panel,
-                                            config                       => vvc_config.bfm_config);
+                                            config                       => vvc_config.bfm_config,
+                                            bit_order                    => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data     := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -368,7 +371,8 @@ begin
                                             action_between_words         => v_cmd.action_between_words,
                                             scope                        => C_SCOPE,
                                             msg_id_panel                 => v_msg_id_panel,
-                                            config                       => vvc_config.bfm_config);
+                                            config                       => vvc_config.bfm_config,
+                                            bit_order                    => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info
@@ -391,7 +395,8 @@ begin
                                   action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                   scope                        => C_SCOPE,
                                   msg_id_panel                 => v_msg_id_panel,
-                                  config                       => vvc_config.bfm_config);
+                                  config                       => vvc_config.bfm_config,
+                                  bit_order                    => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -403,7 +408,8 @@ begin
                                   action_between_words         => v_cmd.action_between_words,
                                   scope                        => C_SCOPE,
                                   msg_id_panel                 => v_msg_id_panel,
-                                  config                       => vvc_config.bfm_config);
+                                  config                       => vvc_config.bfm_config,
+                                  bit_order                    => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info
@@ -425,7 +431,8 @@ begin
                                  action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                  scope                        => C_SCOPE,
                                  msg_id_panel                 => v_msg_id_panel,
-                                 config                       => vvc_config.bfm_config);
+                                 config                       => vvc_config.bfm_config,
+                                 bit_order                    => v_cmd.bit_order);
             else
               spi_master_receive(rx_data                      => v_data_receive(v_num_words - 1 downto 0),
                                  msg                          => format_msg(v_cmd),
@@ -434,7 +441,8 @@ begin
                                  action_between_words         => v_cmd.action_between_words,
                                  scope                        => C_SCOPE,
                                  msg_id_panel                 => v_msg_id_panel,
-                                 config                       => vvc_config.bfm_config);
+                                 config                       => vvc_config.bfm_config,
+                                 bit_order                    => v_cmd.bit_order);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -470,7 +478,8 @@ begin
                                action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                scope                        => C_SCOPE,
                                msg_id_panel                 => v_msg_id_panel,
-                               config                       => vvc_config.bfm_config);
+                               config                       => vvc_config.bfm_config,
+                               bit_order                    => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data_exp := normalize_and_check(v_cmd.data_exp, v_normalized_data_exp, ALLOW_WIDER_NARROWER, "v_cmd.data_exp", "v_normalized_data_exp", "normalizing data_exp to BFM");
@@ -483,7 +492,8 @@ begin
                                action_between_words         => v_cmd.action_between_words,
                                scope                        => C_SCOPE,
                                msg_id_panel                 => v_msg_id_panel,
-                               config                       => vvc_config.bfm_config);
+                               config                       => vvc_config.bfm_config,
+                               bit_order                    => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info
@@ -508,7 +518,8 @@ begin
                                              when_to_start_transfer => v_cmd.when_to_start_transfer,
                                              scope                  => C_SCOPE,
                                              msg_id_panel           => v_msg_id_panel,
-                                             config                 => vvc_config.bfm_config);
+                                             config                 => vvc_config.bfm_config,
+                                             bit_order              => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -521,7 +532,8 @@ begin
                                              when_to_start_transfer => v_cmd.when_to_start_transfer,
                                              scope                  => C_SCOPE,
                                              msg_id_panel           => v_msg_id_panel,
-                                             config                 => vvc_config.bfm_config);
+                                             config                 => vvc_config.bfm_config,
+                                             bit_order              => v_cmd.bit_order);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -559,7 +571,8 @@ begin
                                            when_to_start_transfer => v_cmd.when_to_start_transfer,
                                            scope                  => C_SCOPE,
                                            msg_id_panel           => v_msg_id_panel,
-                                           config                 => vvc_config.bfm_config);
+                                           config                 => vvc_config.bfm_config,
+                                           bit_order              => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data     := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -574,7 +587,8 @@ begin
                                            when_to_start_transfer => v_cmd.when_to_start_transfer,
                                            scope                  => C_SCOPE,
                                            msg_id_panel           => v_msg_id_panel,
-                                           config                 => vvc_config.bfm_config);
+                                           config                 => vvc_config.bfm_config,
+                                           bit_order              => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info
@@ -597,7 +611,8 @@ begin
                                  when_to_start_transfer => v_cmd.when_to_start_transfer,
                                  scope                  => C_SCOPE,
                                  msg_id_panel           => v_msg_id_panel,
-                                 config                 => vvc_config.bfm_config);
+                                 config                 => vvc_config.bfm_config,
+                                 bit_order              => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -609,7 +624,8 @@ begin
                                  when_to_start_transfer => v_cmd.when_to_start_transfer,
                                  scope                  => C_SCOPE,
                                  msg_id_panel           => v_msg_id_panel,
-                                 config                 => vvc_config.bfm_config);
+                                 config                 => vvc_config.bfm_config,
+                                 bit_order              => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info
@@ -632,7 +648,8 @@ begin
                                 when_to_start_transfer => v_cmd.when_to_start_transfer,
                                 scope                  => C_SCOPE,
                                 msg_id_panel           => v_msg_id_panel,
-                                config                 => vvc_config.bfm_config);
+                                config                 => vvc_config.bfm_config,
+                                bit_order              => v_cmd.bit_order);
             else
               spi_slave_receive(rx_data                => v_data_receive(v_num_words - 1 downto 0),
                                 msg                    => format_msg(v_cmd),
@@ -641,7 +658,8 @@ begin
                                 when_to_start_transfer => v_cmd.when_to_start_transfer,
                                 scope                  => C_SCOPE,
                                 msg_id_panel           => v_msg_id_panel,
-                                config                 => vvc_config.bfm_config);
+                                config                 => vvc_config.bfm_config,
+                                bit_order              => v_cmd.bit_order);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -678,7 +696,8 @@ begin
                               when_to_start_transfer => v_cmd.when_to_start_transfer,
                               scope                  => C_SCOPE,
                               msg_id_panel           => v_msg_id_panel,
-                              config                 => vvc_config.bfm_config);
+                              config                 => vvc_config.bfm_config,
+                              bit_order              => v_cmd.bit_order);
             else
               -- normalize
               v_normalized_data_exp := normalize_and_check(v_cmd.data_exp, v_normalized_data_exp, ALLOW_WIDER_NARROWER, "v_cmd.data_exp", "v_normalized_data_exp", "normalizing data_exp to BFM");
@@ -691,7 +710,8 @@ begin
                               when_to_start_transfer => v_cmd.when_to_start_transfer,
                               scope                  => C_SCOPE,
                               msg_id_panel           => v_msg_id_panel,
-                              config                 => vvc_config.bfm_config);
+                              config                 => vvc_config.bfm_config,
+                              bit_order              => v_cmd.bit_order);
             end if;
 
             -- Update vvc transaction info

--- a/bitvis_vip_spi/src/vvc_cmd_pkg.vhd
+++ b/bitvis_vip_spi/src/vvc_cmd_pkg.vhd
@@ -25,6 +25,7 @@ library uvvm_vvc_framework;
 use uvvm_vvc_framework.ti_vvc_framework_support_pkg.all;
 
 use work.transaction_pkg.all;
+use work.spi_bfm_pkg.all;
 
 --=================================================================================================
 --=================================================================================================
@@ -46,6 +47,7 @@ package vvc_cmd_pkg is
     when_to_start_transfer       : t_when_to_start_transfer;
     action_when_transfer_is_done : t_action_when_transfer_is_done;
     action_between_words         : t_action_between_words;
+    bit_order                    : t_bit_order;
     -- Common VVC fields  (Used by td_vvc_framework_common_methods_pkg procedures, and thus mandatory)
     operation                    : t_operation;
     proc_call                    : string(1 to C_VVC_CMD_STRING_MAX_LENGTH);
@@ -72,6 +74,7 @@ package vvc_cmd_pkg is
     when_to_start_transfer       => START_TRANSFER_IMMEDIATE,
     action_when_transfer_is_done => RELEASE_LINE_AFTER_TRANSFER,
     action_between_words         => HOLD_LINE_BETWEEN_WORDS,
+    bit_order                    => MSB_FIRST,
     -- Common VVC fields
     operation                    => NO_OPERATION,
     proc_call                    => (others => NUL),

--- a/bitvis_vip_spi/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_spi/src/vvc_methods_pkg.vhd
@@ -144,7 +144,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -155,7 +155,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_and_receive(
@@ -168,7 +168,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -180,7 +180,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -194,7 +194,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_and_check(
@@ -208,7 +208,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -220,7 +220,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_only(
@@ -232,7 +232,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
 
   procedure spi_master_receive_only(
@@ -245,7 +245,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
 
@@ -258,7 +258,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -271,7 +271,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_check_only(
@@ -284,7 +284,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   );
 
   ----------------------------------------------------------
@@ -300,7 +300,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -311,7 +311,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_and_receive(
@@ -323,7 +323,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -334,7 +334,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -348,7 +348,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_and_check(
@@ -361,7 +361,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -373,7 +373,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_only(
@@ -384,7 +384,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   procedure spi_slave_receive_only(
@@ -396,7 +396,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_receive_only(
@@ -407,7 +407,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -420,7 +420,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_check_only(
@@ -432,7 +432,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   --==============================================================================
@@ -481,7 +481,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -508,7 +508,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words                := RELEASE_LINE_BETWEEN_WORDS;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -523,7 +523,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -542,7 +542,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -569,7 +569,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -585,7 +585,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -604,7 +604,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -631,7 +631,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -650,7 +650,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -677,7 +677,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -693,7 +693,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -716,7 +716,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -733,7 +733,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -756,7 +756,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -774,7 +774,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -793,7 +793,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -809,7 +809,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -827,7 +827,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -851,7 +851,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -869,7 +869,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -893,7 +893,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -913,7 +913,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -939,7 +939,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing                        := data_routing;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -954,7 +954,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -972,7 +972,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -998,7 +998,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing           := data_routing;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1013,7 +1013,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1032,7 +1032,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1059,7 +1059,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1077,7 +1077,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1103,7 +1103,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1119,7 +1119,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1141,7 +1141,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1157,7 +1157,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1180,7 +1180,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length            := v_word_length;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1197,7 +1197,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST;
+    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -1215,7 +1215,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.num_words              := num_words;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1230,7 +1230,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1248,7 +1248,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1272,7 +1272,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1289,7 +1289,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1312,7 +1312,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order            := bit_order;
+    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;

--- a/bitvis_vip_spi/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_spi/src/vvc_methods_pkg.vhd
@@ -144,6 +144,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -153,7 +154,8 @@ package vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_and_receive(
@@ -166,6 +168,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -176,7 +179,8 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -189,7 +193,8 @@ package vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_and_check(
@@ -202,7 +207,8 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -213,7 +219,8 @@ package vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_transmit_only(
@@ -224,7 +231,8 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   procedure spi_master_receive_only(
@@ -237,6 +245,7 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
 
@@ -248,7 +257,8 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -260,7 +270,8 @@ package vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_master_check_only(
@@ -272,7 +283,8 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   ----------------------------------------------------------
@@ -288,6 +300,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -297,7 +310,8 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_and_receive(
@@ -309,6 +323,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -318,7 +333,8 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -331,7 +347,8 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_and_check(
@@ -343,7 +360,8 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -354,7 +372,8 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_transmit_only(
@@ -364,7 +383,8 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   procedure spi_slave_receive_only(
@@ -376,6 +396,7 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_receive_only(
@@ -385,7 +406,8 @@ package vvc_methods_pkg is
     constant num_words              : in positive                 := 1;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   -- Single-word
@@ -397,7 +419,8 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
   -- Multi-word
   procedure spi_slave_check_only(
@@ -408,7 +431,8 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   );
 
   --==============================================================================
@@ -457,6 +481,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -483,6 +508,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words                := RELEASE_LINE_BETWEEN_WORDS;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -496,12 +522,13 @@ package body vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -515,6 +542,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -541,6 +569,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -555,12 +584,13 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -573,7 +603,8 @@ package body vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -600,6 +631,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -617,7 +649,8 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -644,6 +677,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -658,7 +692,8 @@ package body vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -681,6 +716,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -696,7 +732,8 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -719,6 +756,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -736,6 +774,7 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -754,6 +793,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -768,12 +808,13 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_master_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -785,7 +826,8 @@ package body vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -809,6 +851,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -825,7 +868,8 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -849,6 +893,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -868,6 +913,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -893,6 +939,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing                        := data_routing;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -906,12 +953,13 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -924,6 +972,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -949,6 +998,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing           := data_routing;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -962,12 +1012,13 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -980,7 +1031,8 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1007,6 +1059,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1023,7 +1076,8 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1049,6 +1103,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1063,7 +1118,8 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1085,6 +1141,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1099,7 +1156,8 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1122,6 +1180,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length            := v_word_length;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1138,6 +1197,7 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -1155,6 +1215,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.num_words              := num_words;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1168,12 +1229,13 @@ package body vvc_methods_pkg is
     constant num_words              : in positive                 := 1;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
+    spi_slave_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -1185,7 +1247,8 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1209,6 +1272,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1224,7 +1288,8 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
+    constant bit_order               : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1247,6 +1312,7 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
+    shared_vvc_cmd.bit_order            := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;


### PR DESCRIPTION
- Added t_bit_order enumeration type
    - MSB_FIRST
    - LSB_FIRST
- MSB_FIRST is default
- Created helper functions to handle bit order in indexing of tx_data and rx_data for both master and slave