### PR TITLE
Revert "Added configuration for bit order in spi bfm"

### DIFF
--- a/bitvis_vip_spi/src/spi_bfm_pkg.vhd
+++ b/bitvis_vip_spi/src/spi_bfm_pkg.vhd
@@ -32,8 +32,6 @@ package spi_bfm_pkg is
   --===============================================================================================
   constant C_BFM_SCOPE : string := "SPI BFM";
 
-  type t_bit_order is (MSB_FIRST, LSB_FIRST);
-
   type t_spi_if is record
     ss_n : std_logic;                   -- master to slave
     sclk : std_logic;                   -- master to slave
@@ -111,7 +109,6 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -130,7 +127,6 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -145,7 +141,6 @@ package spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -163,8 +158,7 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -178,8 +172,7 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -194,8 +187,7 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -207,8 +199,7 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -223,8 +214,7 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -236,8 +226,7 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -256,8 +245,7 @@ package spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -270,8 +258,7 @@ package spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -294,7 +281,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -312,7 +298,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -329,7 +314,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -345,7 +329,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -360,7 +343,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -374,7 +356,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -391,7 +372,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -406,7 +386,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -420,7 +399,6 @@ package spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   );
 
@@ -439,8 +417,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload without terminate_access
@@ -453,8 +430,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -468,8 +444,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word without terminate_access
@@ -482,8 +457,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -500,8 +474,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload with terminate_access without aborted
@@ -513,8 +486,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload without terminate_access and without aborted
@@ -525,8 +497,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -538,8 +509,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word without terminate_access
@@ -550,8 +520,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -568,8 +537,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload with terminate_access and without aborted
@@ -581,8 +549,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload without terminate_access and without aborted
@@ -593,8 +560,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -606,8 +572,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word without terminate_access
@@ -618,8 +583,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   ------------------------------------------
@@ -639,8 +603,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Overload without terminate_access
@@ -652,8 +615,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word
@@ -666,8 +628,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
   -- Multi-word without terminate_access
@@ -679,8 +640,7 @@ package spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   );
 
 end package spi_bfm_pkg;
@@ -689,40 +649,6 @@ end package spi_bfm_pkg;
 --=================================================================================================
 
 package body spi_bfm_pkg is
-
-  ---------------------------------------------------------------------------------
-  -- Returns correct indexing in tx_data vector based on bit order configuration
-  ---------------------------------------------------------------------------------
-
-  function tx_bit_idx(
-    constant count : in integer;
-    constant size  : in integer;
-    constant order : in t_bit_order
-  ) return integer is
-  begin
-    if order = MSB_FIRST then
-      return size - count - 1;
-    else -- LSB_FIRST
-      return count;
-    end if;
-  end function;
-
-  ---------------------------------------------------------------------------------
-  -- Returns correct indexing in rx_data vector based on bit order configuration
-  ---------------------------------------------------------------------------------
-
-  function rx_bit_idx(
-    constant count : in integer;
-    constant size  : in integer;
-    constant order : in t_bit_order
-  ) return integer is
-  begin
-    if order = MSB_FIRST then
-      return size - count;
-    else -- LSB_FIRST
-      return count - 1;
-    end if;
-  end function;
 
   ---------------------------------------------------------------------------------
   -- initialize spi to dut signals
@@ -770,7 +696,6 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     constant C_LOCAL_PROC_NAME                 : string                                        := "spi_master_transmit_and_receive";
@@ -809,7 +734,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' then
       -- set MOSI together with SS_N when CPHA=0
       if not config.CPHA then
-        mosi       <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+        mosi       <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -826,15 +751,15 @@ package body spi_bfm_pkg is
       while ss_n = '0' and not v_access_done loop
 
         if not config.CPHA then
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
+          v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+          mosi                                  <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
         else                            -- config.CPHA
-          mosi                                  <= v_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+          mosi                                  <= v_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
           wait for config.spi_bit_time / 2;
           sclk                                  <= config.CPOL;
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
+          v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
         end if;
 
         if v_tx_count < C_ACCESS_SIZE - 1 then -- Not done
@@ -847,7 +772,7 @@ package body spi_bfm_pkg is
             v_rx_count                            := v_rx_count + 1;
             -- Sample Last bit on the second to last edge of SCLK (CPOL=0: last rising. CPOL=1: last falling)
             wait for config.spi_bit_time / 2;
-            v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := miso;
+            v_rx_data(C_ACCESS_SIZE - v_rx_count) := miso;
             sclk                                  <= not config.CPOL;
           end if;
           log(config.id_for_bfm, v_proc_call.all & "=> " & to_string(v_tx_data, HEX, SKIP_LEADING_0, INCL_RADIX) & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
@@ -902,13 +827,12 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_master_transmit_and_receive(tx_data, rx_data, msg,
                                     spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso,
-                                    action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                    action_when_transfer_is_done, scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Multi-word
@@ -922,7 +846,6 @@ package body spi_bfm_pkg is
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
     constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
@@ -948,7 +871,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit_and_receive(tx_data(idx), rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, ext_proc_call);
+      spi_master_transmit_and_receive(tx_data(idx), rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, ext_proc_call);
     end loop;
   end procedure;
 
@@ -964,8 +887,7 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string  := "spi_master_transmit_and_check";
     constant C_LOCAL_PROC_CALL : string  := C_LOCAL_PROC_NAME;
@@ -976,7 +898,7 @@ package body spi_bfm_pkg is
     variable v_check_ok      : boolean := true;
     variable v_alert_radix   : t_radix;
   begin
-    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
 
     for i in v_normalized_data_exp'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
@@ -1008,8 +930,7 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME              : string := "spi_master_transmit_and_check";
     constant C_LOCAL_PROC_CALL              : string := C_LOCAL_PROC_NAME;
@@ -1036,7 +957,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
+      spi_master_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config);
     end loop;
   end procedure;
 
@@ -1050,15 +971,14 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_master_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME;
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0);
   begin
-    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -1070,8 +990,7 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1091,7 +1010,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_transmit(tx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
+      spi_master_transmit(tx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config);
     end loop;
   end procedure;
 
@@ -1105,15 +1024,14 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                        := "spi_master_receive";
     constant C_LOCAL_PROC_CALL : string                                        := C_LOCAL_PROC_NAME;
     -- Helper variables
     variable v_tx_data       : std_logic_vector(rx_data'length - 1 downto 0) := (others => '0');
   begin
-    spi_master_transmit_and_receive(v_tx_data, rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(v_tx_data, rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -1125,8 +1043,7 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1146,7 +1063,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_receive(rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
+      spi_master_receive(rx_data(idx), msg, spi_if, v_action_when_transfer_is_done, scope, msg_id_panel, config);
     end loop;
   end procedure;
 
@@ -1161,8 +1078,7 @@ package body spi_bfm_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                         := "spi_master_check";
     constant C_LOCAL_PROC_CALL : string                                         := C_LOCAL_PROC_NAME;
@@ -1174,7 +1090,7 @@ package body spi_bfm_pkg is
     variable v_check_ok      : boolean                                        := true;
     variable v_alert_radix   : t_radix;
   begin
-    spi_master_transmit_and_receive(v_tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_master_transmit_and_receive(v_tx_data, v_rx_data, msg, spi_if, action_when_transfer_is_done, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
 
     for i in v_normalized_data_exp'range loop
       -- Allow don't care in expected value and use match strictness from config for comparison
@@ -1205,8 +1121,7 @@ package body spi_bfm_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_BFM_SCOPE;
     constant msg_id_panel                 : in t_msg_id_panel                 := shared_msg_id_panel;
-    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                       : in t_spi_bfm_config               := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     variable v_action_when_transfer_is_done : t_action_when_transfer_is_done; -- between words and after transfer
   begin
@@ -1226,7 +1141,7 @@ package body spi_bfm_pkg is
           end if;
       end case;
       -- call single-word procedure
-      spi_master_check(data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config, bit_order);
+      spi_master_check(data_exp(idx), msg, spi_if, alert_level, v_action_when_transfer_is_done, scope, msg_id_panel, config);
     end loop;
   end procedure;
 
@@ -1249,7 +1164,6 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
     -- Local_proc_name/call used if called from sequencer or VVC
@@ -1305,7 +1219,7 @@ package body spi_bfm_pkg is
     if ss_n = '0' and not v_terminated then
       -- set MISO together with SS_N when CPHA=0
       if not config.CPHA then
-        miso       <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+        miso       <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
         v_tx_count := v_tx_count + 1;
       end if;
 
@@ -1327,13 +1241,13 @@ package body spi_bfm_pkg is
       while (ss_n = '0') and not(v_access_done) and not(v_terminated) loop
 
         if not config.CPHA then
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
+          v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+          miso                                  <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
         else                            -- config.CPHA
-          miso                                  <= v_bfm_tx_data(tx_bit_idx(v_tx_count, C_ACCESS_SIZE, bit_order));
+          miso                                  <= v_bfm_tx_data(C_ACCESS_SIZE - v_tx_count - 1);
           wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1') or (ss_n = '1');
-          v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
+          v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
         end if;
 
         if terminate_access = '1' then
@@ -1374,7 +1288,7 @@ package body spi_bfm_pkg is
     -- Sample last bit
     if (config.CPHA = '0') and not (v_terminated) then
       v_rx_count                            := v_rx_count + 1;
-      v_rx_data(rx_bit_idx(v_rx_count, C_ACCESS_SIZE, bit_order)) := mosi;
+      v_rx_data(C_ACCESS_SIZE - v_rx_count) := mosi;
       wait until (sclk'event and sclk = config.CPOL) or (terminate_access = '1')  or (ss_n = '1');
     end if;
 
@@ -1429,13 +1343,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                   sclk, ss_n, mosi, miso, terminate_access, ERROR, when_to_start_transfer, scope,
-                                  msg_id_panel, config, bit_order, ext_proc_call);
+                                  msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1451,13 +1364,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                   sclk, ss_n, mosi, miso, no_access_termination, ERROR, when_to_start_transfer, scope,
-                                  msg_id_panel, config, bit_order, ext_proc_call);
+                                  msg_id_panel, config, ext_proc_call);
   end procedure;
 
   procedure spi_slave_transmit_and_receive(
@@ -1472,13 +1384,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, terminate_access,
-                                   NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                   NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Overload with terminate_access without aborted
@@ -1492,13 +1403,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, terminate_access, ERROR,
-                                   when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                   when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1511,13 +1421,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg,
                                    spi_if.sclk, spi_if.ss_n, spi_if.mosi, spi_if.miso, no_access_termination, ERROR,
-                                   when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                   when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Multi-word
@@ -1533,7 +1442,6 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
@@ -1543,7 +1451,7 @@ package body spi_bfm_pkg is
     end if;
     for idx in 0 to (tx_data'length - 1) loop
       exit when (terminate_access = '1');
-      spi_slave_transmit_and_receive(tx_data(idx), rx_data(idx), aborted, msg, spi_if, terminate_access, aborted_alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order, ext_proc_call);
+      spi_slave_transmit_and_receive(tx_data(idx), rx_data(idx), aborted, msg, spi_if, terminate_access, aborted_alert_level, when_to_start_transfer, scope, msg_id_panel, config, ext_proc_call);
       exit when (aborted = True);
     end loop;
   end procedure;
@@ -1559,13 +1467,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg, spi_if,
                                 terminate_access, ERROR, when_to_start_transfer,
-                                scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   -- Multi-word without terminate_access and without aborted
@@ -1578,13 +1485,12 @@ package body spi_bfm_pkg is
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
     constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := "" -- External proc_call. Overwrite if called from another BFM procedure
   ) is
   begin
     spi_slave_transmit_and_receive(tx_data, rx_data, v_no_aborted, msg, spi_if,
                                 no_access_termination, ERROR, when_to_start_transfer,
-                                scope, msg_id_panel, config, bit_order, ext_proc_call);
+                                scope, msg_id_panel, config, ext_proc_call);
   end procedure;
 
   ------------------------------------------
@@ -1600,8 +1506,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string  := "spi_slave_transmit_and_check";
     constant C_LOCAL_PROC_CALL : string  := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1613,7 +1518,7 @@ package body spi_bfm_pkg is
     variable v_aborted       : boolean := false;
     variable v_alert_radix   : t_radix;
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
 
     if terminate_access = '0' then
       for i in v_normalized_data_exp'range loop
@@ -1650,13 +1555,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_transmit_and_check(tx_data, data_exp, msg,
                                 spi_if, no_access_termination, alert_level,
-                                when_to_start_transfer, scope, msg_id_panel, config, bit_order);
+                                when_to_start_transfer, scope, msg_id_panel, config);
   end procedure;
 
   -- Multi-word
@@ -1670,8 +1574,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_CALL : string := "spi_slave_transmit_and_check"; -- External proc_call; overwrite if called from other BFM procedure like spi_*_check
   begin
@@ -1682,7 +1585,7 @@ package body spi_bfm_pkg is
     for idx in 0 to (tx_data'length - 1) loop
       exit when (terminate_access = '1');
       -- call single-word procedure - will handle error checking
-      spi_slave_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order);
+      spi_slave_transmit_and_check(tx_data(idx), data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config);
     end loop;
 
     if terminate_access = '1' then
@@ -1700,13 +1603,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_transmit_and_check(tx_data, data_exp, msg,
                                 spi_if, no_access_termination, alert_level,
-                                when_to_start_transfer, scope, msg_id_panel, config, bit_order);
+                                when_to_start_transfer, scope, msg_id_panel, config);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1721,15 +1623,14 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0); -- := (others => '0');
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload with terminate_access and without aborted
@@ -1741,15 +1642,14 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_rx_data       : std_logic_vector(tx_data'length - 1 downto 0); -- := (others => '0');
   begin
-    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_no_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_rx_data, v_no_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload without terminate_access without aborted
@@ -1760,13 +1660,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_transmit(tx_data, v_no_aborted, msg, spi_if,
                       no_access_termination, when_to_start_transfer,
-                      scope, msg_id_panel, config, bit_order);
+                      scope, msg_id_panel, config);
   end procedure;
 
   -- Multi-word
@@ -1778,8 +1677,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                                                   := "spi_slave_transmit";
     constant C_LOCAL_PROC_CALL : string                                                                   := C_LOCAL_PROC_NAME & "(" & to_string(tx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1787,7 +1685,7 @@ package body spi_bfm_pkg is
     variable v_tx_data       : t_slv_array(tx_data'length - 1 downto 0)(tx_data(0)'length - 1 downto 0) := (others => (others => '0'));
   begin
     -- call multi-word procedure
-    spi_slave_transmit_and_receive(tx_data, v_tx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(tx_data, v_tx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word without terminate_access
@@ -1798,13 +1696,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_transmit(tx_data, msg, spi_if,
                       no_access_termination, when_to_start_transfer,
-                      scope, msg_id_panel, config, bit_order);
+                      scope, msg_id_panel, config);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1819,15 +1716,14 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                        := "spi_slave_receive";
     constant C_LOCAL_PROC_CALL : string                                        := C_LOCAL_PROC_NAME & "(" & to_string(rx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
     -- Helper variables
     variable v_tx_data       : std_logic_vector(rx_data'length - 1 downto 0) := (others => '0');
   begin
-    spi_slave_transmit_and_receive(v_tx_data, rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_tx_data, rx_data, aborted, msg, spi_if, terminate_access, NO_ALERT, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Overload with terminate_access and without aborted
@@ -1839,13 +1735,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_receive(rx_data, v_no_aborted, msg, spi_if,
                     terminate_access, when_to_start_transfer,
-                    scope, msg_id_panel, config, bit_order);
+                    scope, msg_id_panel, config);
   end procedure;
 
   -- Overload without terminate_access and without aborted
@@ -1856,13 +1751,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_receive(rx_data, v_no_aborted, msg, spi_if,
                     no_access_termination, when_to_start_transfer,
-                    scope, msg_id_panel, config, bit_order);
+                    scope, msg_id_panel, config);
   end procedure;
 
   -- Multi-word
@@ -1874,8 +1768,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                                                   := "spi_slave_receive";
     constant C_LOCAL_PROC_CALL : string                                                                   := C_LOCAL_PROC_NAME & "(" & to_string(rx_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1883,7 +1776,7 @@ package body spi_bfm_pkg is
     variable v_rx_data       : t_slv_array(rx_data'length - 1 downto 0)(rx_data(0)'length - 1 downto 0) := (others => (others => '0'));
   begin
     -- call multi-word procedure
-    spi_slave_transmit_and_receive(v_rx_data, rx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_rx_data, rx_data, msg, spi_if, terminate_access, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
   end procedure;
 
   -- Multi-word without terminate_access
@@ -1894,13 +1787,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_receive(rx_data, msg, spi_if,
                     no_access_termination, when_to_start_transfer,
-                    scope, msg_id_panel, config, bit_order);
+                    scope, msg_id_panel, config);
   end procedure;
 
   ---------------------------------------------------------------------------------
@@ -1915,8 +1807,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string                                         := "spi_slave_check";
     constant C_LOCAL_PROC_CALL : string                                         := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1929,7 +1820,7 @@ package body spi_bfm_pkg is
     variable v_alert_radix   : t_radix;
     variable v_aborted       : boolean := false;
   begin
-    spi_slave_transmit_and_receive(v_tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, bit_order, C_LOCAL_PROC_CALL);
+    spi_slave_transmit_and_receive(v_tx_data, v_rx_data, v_aborted, msg, spi_if, terminate_access, ERROR, when_to_start_transfer, scope, msg_id_panel, config, C_LOCAL_PROC_CALL);
 
     if terminate_access = '0' then
 
@@ -1966,13 +1857,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_check(data_exp, msg, spi_if,
                   no_access_termination, alert_level, when_to_start_transfer,
-                  scope, msg_id_panel, config, bit_order);
+                  scope, msg_id_panel, config);
   end procedure;
 
   -- Multi-word
@@ -1985,8 +1875,7 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
     constant C_LOCAL_PROC_NAME : string := "spi_slave_check";
     constant C_LOCAL_PROC_CALL : string := C_LOCAL_PROC_NAME & "(" & to_string(data_exp, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
@@ -1994,7 +1883,7 @@ package body spi_bfm_pkg is
     for idx in 0 to (data_exp'length - 1) loop
       exit when (terminate_access = '1');
       -- call singl-word procedure - will handle error check
-      spi_slave_check(data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config, bit_order);
+      spi_slave_check(data_exp(idx), msg, spi_if, terminate_access, alert_level, when_to_start_transfer, scope, msg_id_panel, config);
     end loop;
 
     if terminate_access = '1' then
@@ -2011,13 +1900,12 @@ package body spi_bfm_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_BFM_SCOPE;
     constant msg_id_panel           : in t_msg_id_panel           := shared_msg_id_panel;
-    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT;
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST
+    constant config                 : in t_spi_bfm_config         := C_SPI_BFM_CONFIG_DEFAULT
   ) is
   begin
     spi_slave_check(data_exp, msg, spi_if,
                   no_access_termination, alert_level, when_to_start_transfer,
-                  scope, msg_id_panel, config, bit_order);
+                  scope, msg_id_panel, config);
   end procedure;
 
 end package body spi_bfm_pkg;

--- a/bitvis_vip_spi/src/spi_vvc.vhd
+++ b/bitvis_vip_spi/src/spi_vvc.vhd
@@ -304,8 +304,7 @@ begin
                                               action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                               scope                        => C_SCOPE,
                                               msg_id_panel                 => v_msg_id_panel,
-                                              config                       => vvc_config.bfm_config,
-                                              bit_order                    => v_cmd.bit_order);
+                                              config                       => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -317,8 +316,7 @@ begin
                                               action_between_words         => v_cmd.action_between_words,
                                               scope                        => C_SCOPE,
                                               msg_id_panel                 => v_msg_id_panel,
-                                              config                       => vvc_config.bfm_config,
-                                              bit_order                    => v_cmd.bit_order);
+                                              config                       => vvc_config.bfm_config);
               v_result          := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
 
@@ -356,8 +354,7 @@ begin
                                             action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                             scope                        => C_SCOPE,
                                             msg_id_panel                 => v_msg_id_panel,
-                                            config                       => vvc_config.bfm_config,
-                                            bit_order                    => v_cmd.bit_order);
+                                            config                       => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data     := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -371,8 +368,7 @@ begin
                                             action_between_words         => v_cmd.action_between_words,
                                             scope                        => C_SCOPE,
                                             msg_id_panel                 => v_msg_id_panel,
-                                            config                       => vvc_config.bfm_config,
-                                            bit_order                    => v_cmd.bit_order);
+                                            config                       => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info
@@ -395,8 +391,7 @@ begin
                                   action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                   scope                        => C_SCOPE,
                                   msg_id_panel                 => v_msg_id_panel,
-                                  config                       => vvc_config.bfm_config,
-                                  bit_order                    => v_cmd.bit_order);
+                                  config                       => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -408,8 +403,7 @@ begin
                                   action_between_words         => v_cmd.action_between_words,
                                   scope                        => C_SCOPE,
                                   msg_id_panel                 => v_msg_id_panel,
-                                  config                       => vvc_config.bfm_config,
-                                  bit_order                    => v_cmd.bit_order);
+                                  config                       => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info
@@ -431,8 +425,7 @@ begin
                                  action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                  scope                        => C_SCOPE,
                                  msg_id_panel                 => v_msg_id_panel,
-                                 config                       => vvc_config.bfm_config,
-                                 bit_order                    => v_cmd.bit_order);
+                                 config                       => vvc_config.bfm_config);
             else
               spi_master_receive(rx_data                      => v_data_receive(v_num_words - 1 downto 0),
                                  msg                          => format_msg(v_cmd),
@@ -441,8 +434,7 @@ begin
                                  action_between_words         => v_cmd.action_between_words,
                                  scope                        => C_SCOPE,
                                  msg_id_panel                 => v_msg_id_panel,
-                                 config                       => vvc_config.bfm_config,
-                                 bit_order                    => v_cmd.bit_order);
+                                 config                       => vvc_config.bfm_config);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -478,8 +470,7 @@ begin
                                action_when_transfer_is_done => v_cmd.action_when_transfer_is_done,
                                scope                        => C_SCOPE,
                                msg_id_panel                 => v_msg_id_panel,
-                               config                       => vvc_config.bfm_config,
-                               bit_order                    => v_cmd.bit_order);
+                               config                       => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data_exp := normalize_and_check(v_cmd.data_exp, v_normalized_data_exp, ALLOW_WIDER_NARROWER, "v_cmd.data_exp", "v_normalized_data_exp", "normalizing data_exp to BFM");
@@ -492,8 +483,7 @@ begin
                                action_between_words         => v_cmd.action_between_words,
                                scope                        => C_SCOPE,
                                msg_id_panel                 => v_msg_id_panel,
-                               config                       => vvc_config.bfm_config,
-                               bit_order                    => v_cmd.bit_order);
+                               config                       => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info
@@ -518,8 +508,7 @@ begin
                                              when_to_start_transfer => v_cmd.when_to_start_transfer,
                                              scope                  => C_SCOPE,
                                              msg_id_panel           => v_msg_id_panel,
-                                             config                 => vvc_config.bfm_config,
-                                             bit_order              => v_cmd.bit_order);
+                                             config                 => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -532,8 +521,7 @@ begin
                                              when_to_start_transfer => v_cmd.when_to_start_transfer,
                                              scope                  => C_SCOPE,
                                              msg_id_panel           => v_msg_id_panel,
-                                             config                 => vvc_config.bfm_config,
-                                             bit_order              => v_cmd.bit_order);
+                                             config                 => vvc_config.bfm_config);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -571,8 +559,7 @@ begin
                                            when_to_start_transfer => v_cmd.when_to_start_transfer,
                                            scope                  => C_SCOPE,
                                            msg_id_panel           => v_msg_id_panel,
-                                           config                 => vvc_config.bfm_config,
-                                           bit_order              => v_cmd.bit_order);
+                                           config                 => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data     := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -587,8 +574,7 @@ begin
                                            when_to_start_transfer => v_cmd.when_to_start_transfer,
                                            scope                  => C_SCOPE,
                                            msg_id_panel           => v_msg_id_panel,
-                                           config                 => vvc_config.bfm_config,
-                                           bit_order              => v_cmd.bit_order);
+                                           config                 => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info
@@ -611,8 +597,7 @@ begin
                                  when_to_start_transfer => v_cmd.when_to_start_transfer,
                                  scope                  => C_SCOPE,
                                  msg_id_panel           => v_msg_id_panel,
-                                 config                 => vvc_config.bfm_config,
-                                 bit_order              => v_cmd.bit_order);
+                                 config                 => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data := normalize_and_check(v_cmd.data, v_normalized_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalized_data", "normalizing data to BFM");
@@ -624,8 +609,7 @@ begin
                                  when_to_start_transfer => v_cmd.when_to_start_transfer,
                                  scope                  => C_SCOPE,
                                  msg_id_panel           => v_msg_id_panel,
-                                 config                 => vvc_config.bfm_config,
-                                 bit_order              => v_cmd.bit_order);
+                                 config                 => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info
@@ -648,8 +632,7 @@ begin
                                 when_to_start_transfer => v_cmd.when_to_start_transfer,
                                 scope                  => C_SCOPE,
                                 msg_id_panel           => v_msg_id_panel,
-                                config                 => vvc_config.bfm_config,
-                                bit_order              => v_cmd.bit_order);
+                                config                 => vvc_config.bfm_config);
             else
               spi_slave_receive(rx_data                => v_data_receive(v_num_words - 1 downto 0),
                                 msg                    => format_msg(v_cmd),
@@ -658,8 +641,7 @@ begin
                                 when_to_start_transfer => v_cmd.when_to_start_transfer,
                                 scope                  => C_SCOPE,
                                 msg_id_panel           => v_msg_id_panel,
-                                config                 => vvc_config.bfm_config,
-                                bit_order              => v_cmd.bit_order);
+                                config                 => vvc_config.bfm_config);
               v_result := normalize_and_check(v_data_receive, v_result, ALLOW_WIDER_NARROWER, "v_data_receive", "v_result", "normalizing data to result");
             end if;
             -- Store the result
@@ -696,8 +678,7 @@ begin
                               when_to_start_transfer => v_cmd.when_to_start_transfer,
                               scope                  => C_SCOPE,
                               msg_id_panel           => v_msg_id_panel,
-                              config                 => vvc_config.bfm_config,
-                              bit_order              => v_cmd.bit_order);
+                              config                 => vvc_config.bfm_config);
             else
               -- normalize
               v_normalized_data_exp := normalize_and_check(v_cmd.data_exp, v_normalized_data_exp, ALLOW_WIDER_NARROWER, "v_cmd.data_exp", "v_normalized_data_exp", "normalizing data_exp to BFM");
@@ -710,8 +691,7 @@ begin
                               when_to_start_transfer => v_cmd.when_to_start_transfer,
                               scope                  => C_SCOPE,
                               msg_id_panel           => v_msg_id_panel,
-                              config                 => vvc_config.bfm_config,
-                              bit_order              => v_cmd.bit_order);
+                              config                 => vvc_config.bfm_config);
             end if;
 
             -- Update vvc transaction info

--- a/bitvis_vip_spi/src/vvc_cmd_pkg.vhd
+++ b/bitvis_vip_spi/src/vvc_cmd_pkg.vhd
@@ -25,7 +25,6 @@ library uvvm_vvc_framework;
 use uvvm_vvc_framework.ti_vvc_framework_support_pkg.all;
 
 use work.transaction_pkg.all;
-use work.spi_bfm_pkg.all;
 
 --=================================================================================================
 --=================================================================================================
@@ -47,7 +46,6 @@ package vvc_cmd_pkg is
     when_to_start_transfer       : t_when_to_start_transfer;
     action_when_transfer_is_done : t_action_when_transfer_is_done;
     action_between_words         : t_action_between_words;
-    bit_order                    : t_bit_order;
     -- Common VVC fields  (Used by td_vvc_framework_common_methods_pkg procedures, and thus mandatory)
     operation                    : t_operation;
     proc_call                    : string(1 to C_VVC_CMD_STRING_MAX_LENGTH);
@@ -74,7 +72,6 @@ package vvc_cmd_pkg is
     when_to_start_transfer       => START_TRANSFER_IMMEDIATE,
     action_when_transfer_is_done => RELEASE_LINE_AFTER_TRANSFER,
     action_between_words         => HOLD_LINE_BETWEEN_WORDS,
-    bit_order                    => MSB_FIRST,
     -- Common VVC fields
     operation                    => NO_OPERATION,
     proc_call                    => (others => NUL),

--- a/bitvis_vip_spi/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_spi/src/vvc_methods_pkg.vhd
@@ -144,7 +144,6 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -154,8 +153,7 @@ package vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_master_transmit_and_receive(
@@ -168,7 +166,6 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
   procedure spi_master_transmit_and_receive(
@@ -179,8 +176,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -193,8 +189,7 @@ package vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_master_transmit_and_check(
@@ -207,8 +202,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -219,8 +213,7 @@ package vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_master_transmit_only(
@@ -231,8 +224,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   procedure spi_master_receive_only(
@@ -245,7 +237,6 @@ package vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   );
 
@@ -257,8 +248,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -270,8 +260,7 @@ package vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_master_check_only(
@@ -283,8 +272,7 @@ package vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   ----------------------------------------------------------
@@ -300,7 +288,6 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -310,8 +297,7 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_slave_transmit_and_receive(
@@ -323,7 +309,6 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_transmit_and_receive(
@@ -333,8 +318,7 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -347,8 +331,7 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_slave_transmit_and_check(
@@ -360,8 +343,7 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -372,8 +354,7 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_slave_transmit_only(
@@ -383,8 +364,7 @@ package vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   procedure spi_slave_receive_only(
@@ -396,7 +376,6 @@ package vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   );
   procedure spi_slave_receive_only(
@@ -406,8 +385,7 @@ package vvc_methods_pkg is
     constant num_words              : in positive                 := 1;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   -- Single-word
@@ -419,8 +397,7 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
   -- Multi-word
   procedure spi_slave_check_only(
@@ -431,8 +408,7 @@ package vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
   --==============================================================================
@@ -481,7 +457,6 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -508,7 +483,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words                := RELEASE_LINE_BETWEEN_WORDS;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -522,13 +496,12 @@ package body vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -542,7 +515,6 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -569,7 +541,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -584,13 +555,12 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_master_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -603,8 +573,7 @@ package body vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -631,7 +600,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -649,8 +617,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -677,7 +644,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -692,8 +658,7 @@ package body vvc_methods_pkg is
     constant msg                          : in string;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -716,7 +681,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.action_when_transfer_is_done        := action_when_transfer_is_done;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -732,8 +696,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -756,7 +719,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -774,7 +736,6 @@ package body vvc_methods_pkg is
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST;
     constant ext_proc_call                : in string                         := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -793,7 +754,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done := action_when_transfer_is_done;
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -808,13 +768,12 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_master_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_master_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, action_when_transfer_is_done, action_between_words, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -826,8 +785,7 @@ package body vvc_methods_pkg is
     constant alert_level                  : in t_alert_level                  := error;
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -851,7 +809,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_when_transfer_is_done            := action_when_transfer_is_done;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -868,8 +825,7 @@ package body vvc_methods_pkg is
     constant action_when_transfer_is_done : in t_action_when_transfer_is_done := RELEASE_LINE_AFTER_TRANSFER;
     constant action_between_words         : in t_action_between_words         := HOLD_LINE_BETWEEN_WORDS;
     constant scope                        : in string                         := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order                    : in t_bit_order                    := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel          : in t_msg_id_panel                 := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -893,7 +849,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.action_between_words         := action_between_words;
     shared_vvc_cmd.alert_level                  := alert_level;
     shared_vvc_cmd.parent_msg_id_panel          := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                    := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -913,7 +868,6 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -939,7 +893,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing                        := data_routing;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -953,13 +906,12 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Multi-word
@@ -972,7 +924,6 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -998,7 +949,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.data_routing           := data_routing;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1012,13 +962,12 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_slave_transmit_and_receive(VVCT, vvc_instance_idx, data, NA, msg, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -1031,8 +980,7 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1059,7 +1007,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1076,8 +1023,7 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1103,7 +1049,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1118,8 +1063,7 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1141,7 +1085,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length                         := v_word_length;
     shared_vvc_cmd.when_to_start_transfer              := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel                 := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                           := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1156,8 +1099,7 @@ package body vvc_methods_pkg is
     constant msg                    : in string;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME       : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL       : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1180,7 +1122,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.word_length            := v_word_length;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1197,7 +1138,6 @@ package body vvc_methods_pkg is
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
     constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST;
     constant ext_proc_call          : in string                   := ""
   ) is
     constant C_PROC_NAME       : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
@@ -1215,7 +1155,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.num_words              := num_words;
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1229,13 +1168,12 @@ package body vvc_methods_pkg is
     constant num_words              : in positive                 := 1;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME : string := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
   begin
-    spi_slave_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, when_to_start_transfer, scope, parent_msg_id_panel, bit_order, C_PROC_CALL);
+    spi_slave_receive_only(VVCT, vvc_instance_idx, NA, msg, num_words, when_to_start_transfer, scope, parent_msg_id_panel, C_PROC_CALL);
   end procedure;
 
   -- Single-word
@@ -1247,8 +1185,7 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1272,7 +1209,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer                  := when_to_start_transfer;
     shared_vvc_cmd.alert_level                             := alert_level;
     shared_vvc_cmd.parent_msg_id_panel                     := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order                               := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;
@@ -1288,8 +1224,7 @@ package body vvc_methods_pkg is
     constant alert_level            : in t_alert_level            := error;
     constant when_to_start_transfer : in t_when_to_start_transfer := START_TRANSFER_ON_NEXT_SS;
     constant scope                  : in string                   := C_VVC_CMD_SCOPE_DEFAULT;
-    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL; -- Only intended for usage by parent HVVCs
-    constant bit_order              : in t_bit_order              := MSB_FIRST -- Bit order for SPI transfers
+    constant parent_msg_id_panel    : in t_msg_id_panel           := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   ) is
     constant C_PROC_NAME           : string                                                                                := get_procedure_name_from_instance_name(vvc_instance_idx'instance_name);
     constant C_PROC_CALL           : string                                                                                := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) & ")";
@@ -1312,7 +1247,6 @@ package body vvc_methods_pkg is
     shared_vvc_cmd.when_to_start_transfer := when_to_start_transfer;
     shared_vvc_cmd.alert_level            := alert_level;
     shared_vvc_cmd.parent_msg_id_panel    := parent_msg_id_panel;
-    shared_vvc_cmd.bit_order              := bit_order;
     if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
       v_msg_id_panel := parent_msg_id_panel;
     end if;


### PR DESCRIPTION
Reverts UVVM/UVVM#298

The UVVM team has decided to put the _bit_order_ constant inside the SPI BFM config and release a new major version to be consistent with the existing code.