### PR TITLE
Avalon-MM modifications

### DIFF
--- a/bitvis_vip_avalon_mm/src/avalon_mm_bfm_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/avalon_mm_bfm_pkg.vhd
@@ -119,6 +119,7 @@ package avalon_mm_bfm_pkg is
   -- All BFM output signals are initialized to 0
   -- All BFM input signals are initialized to Z
   function init_avalon_mm_if_signals(
+    is_host    : boolean;
     addr_width : natural;
     data_width : natural;
     lock_value : std_logic := '0'
@@ -241,6 +242,28 @@ package avalon_mm_bfm_pkg is
     constant config       : in t_avalon_mm_bfm_config := C_AVALON_MM_BFM_CONFIG_DEFAULT
   );
 
+  procedure avalon_mm_receive(
+    variable addr_value   : out std_logic_vector;
+    variable data_value   : out std_logic_vector;
+    constant msg          : in string;
+    signal   clk          : in std_logic;
+    signal   avalon_mm_if : inout t_avalon_mm_if;
+    constant scope        : in string                 := C_BFM_SCOPE;
+    constant msg_id_panel : in t_msg_id_panel         := shared_msg_id_panel;
+    constant config       : in t_avalon_mm_bfm_config := C_AVALON_MM_BFM_CONFIG_DEFAULT
+  );
+
+  procedure avalon_mm_respond(
+    variable addr_value   : out std_logic_vector;
+    variable data_value   : in std_logic_vector;
+    constant msg          : in string;
+    signal   clk          : in std_logic;
+    signal   avalon_mm_if : inout t_avalon_mm_if;
+    constant scope        : in string                 := C_BFM_SCOPE;
+    constant msg_id_panel : in t_msg_id_panel         := shared_msg_id_panel;
+    constant config       : in t_avalon_mm_bfm_config := C_AVALON_MM_BFM_CONFIG_DEFAULT
+  );
+
 end package avalon_mm_bfm_pkg;
 
 --=================================================================================================
@@ -249,6 +272,7 @@ end package avalon_mm_bfm_pkg;
 package body avalon_mm_bfm_pkg is
 
   function init_avalon_mm_if_signals(
+    is_host    : boolean;
     addr_width : natural;
     data_width : natural;
     lock_value : std_logic := '0'
@@ -258,23 +282,43 @@ package body avalon_mm_bfm_pkg is
                                        writedata(data_width - 1 downto 0),
                                        readdata(data_width - 1 downto 0));
   begin
-    -- BFM to DUT signals
-    v_result.reset         := '0';
-    v_result.address       := (v_result.address'range => '0');
-    v_result.begintransfer := '0';
-    v_result.byte_enable   := (v_result.byte_enable'range => '1');
-    v_result.chipselect    := '0';
-    v_result.write         := '0';
-    v_result.writedata     := (v_result.writedata'range => '0');
-    v_result.read          := '0';
-    v_result.lock          := lock_value;
+    if is_host then
+      -- BFM to DUT signals
+      v_result.reset         := '0';
+      v_result.address       := (v_result.address'range => '0');
+      v_result.begintransfer := '0';
+      v_result.byte_enable   := (v_result.byte_enable'range => '1');
+      v_result.chipselect    := '0';
+      v_result.write         := '0';
+      v_result.writedata     := (v_result.writedata'range => '0');
+      v_result.read          := '0';
+      v_result.lock          := lock_value;
 
-    -- DUT to BFM signals
-    v_result.readdata      := (v_result.readdata'range => 'Z');
-    v_result.response      := (v_result.response'range => 'Z');
-    v_result.waitrequest   := 'Z';
-    v_result.readdatavalid := 'Z';
-    v_result.irq           := 'Z';
+      -- DUT to BFM signals
+      v_result.readdata      := (v_result.readdata'range => 'Z');
+      v_result.response      := (v_result.response'range => 'Z');
+      v_result.waitrequest   := 'Z';
+      v_result.readdatavalid := 'Z';
+      v_result.irq           := 'Z';
+    else
+      -- DUT to BFM signals
+      v_result.reset         := 'Z';
+      v_result.address       := (v_result.address'range => 'Z');
+      v_result.begintransfer := 'Z';
+      v_result.byte_enable   := (v_result.byte_enable'range => 'Z');
+      v_result.chipselect    := 'Z';
+      v_result.write         := 'Z';
+      v_result.writedata     := (v_result.writedata'range => 'Z');
+      v_result.read          := 'Z';
+      v_result.lock          := 'Z';
+
+      -- BFM to DUT signals
+      v_result.readdata      := (v_result.readdata'range => '0');
+      v_result.response      := (v_result.response'range => '0');
+      v_result.waitrequest   := '0';
+      v_result.readdatavalid := '0';
+      v_result.irq           := '0';
+    end if;
 
     return v_result;
   end function;
@@ -394,7 +438,7 @@ package body avalon_mm_bfm_pkg is
     -- Wait according to config.bfm_sync setup
     wait_on_bfm_exit(clk, config.bfm_sync, config.hold_time, v_time_of_falling_edge, v_time_of_rising_edge);
 
-    avalon_mm_if <= init_avalon_mm_if_signals(avalon_mm_if.address'length, avalon_mm_if.writedata'length, avalon_mm_if.lock);
+    avalon_mm_if <= init_avalon_mm_if_signals(true, avalon_mm_if.address'length, avalon_mm_if.writedata'length, avalon_mm_if.lock);
 
     log(config.id_for_bfm, C_PROC_CALL & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
   end procedure avalon_mm_write;
@@ -466,7 +510,7 @@ package body avalon_mm_bfm_pkg is
     constant C_PROC_CALL : string := "avalon_mm_reset(num_rst_cycles=" & to_string(num_rst_cycles) & ")";
   begin
     log(config.id_for_bfm, C_PROC_CALL & "." & add_msg_delimiter(msg), scope, msg_id_panel);
-    avalon_mm_if       <= init_avalon_mm_if_signals(avalon_mm_if.address'length, avalon_mm_if.writedata'length);
+    avalon_mm_if       <= init_avalon_mm_if_signals(true, avalon_mm_if.address'length, avalon_mm_if.writedata'length);
     avalon_mm_if.reset <= '1';
     for i in 1 to num_rst_cycles loop
       wait until rising_edge(clk);
@@ -562,7 +606,7 @@ package body avalon_mm_bfm_pkg is
       end loop;
     end if;
 
-    avalon_mm_if <= init_avalon_mm_if_signals(avalon_mm_if.address'length, avalon_mm_if.writedata'length, avalon_mm_if.lock);
+    avalon_mm_if <= init_avalon_mm_if_signals(true, avalon_mm_if.address'length, avalon_mm_if.writedata'length, avalon_mm_if.lock);
 
     -- If wait request is not asserted on the first cycle, wait until the next
     -- rising edge until data becomes available by the agent
@@ -720,5 +764,121 @@ package body avalon_mm_bfm_pkg is
     log(config.id_for_bfm, C_PROC_CALL & "." & add_msg_delimiter(msg), scope, msg_id_panel);
     avalon_mm_if.lock <= '0';
   end procedure avalon_mm_unlock;
+
+  procedure avalon_mm_receive(
+    variable addr_value   : out std_logic_vector;
+    variable data_value   : out std_logic_vector;
+    constant msg          : in string;
+    signal   clk          : in std_logic;
+    signal   avalon_mm_if : inout t_avalon_mm_if;
+    constant scope        : in string                 := C_BFM_SCOPE;
+    constant msg_id_panel : in t_msg_id_panel         := shared_msg_id_panel;
+    constant config       : in t_avalon_mm_bfm_config := C_AVALON_MM_BFM_CONFIG_DEFAULT
+  ) is
+    constant C_PROC_NAME    : string                 := "avalon_mm_receive";
+    constant C_PROC_CALL : string := "avalon_mm_receive()";
+
+    variable v_normalized_addr      : std_logic_vector(avalon_mm_if.address'length - 1 downto 0) := normalize_and_check(addr_value, avalon_mm_if.address, ALLOW_NARROWER, "addr", "avalon_mm_if.address", msg);
+    variable v_normalized_data      : std_logic_vector(avalon_mm_if.readdata'length - 1 downto 0) := normalize_and_check(data_value, avalon_mm_if.readdata, ALLOW_NARROWER, "data", "avalon_mm_if.readdata", msg);
+    variable v_timeout              : boolean := false;
+  begin
+
+    check_value(not config.use_waitrequest, TB_FAILURE, "not implemented: waitrequest support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(config.use_readdatavalid, TB_FAILURE, "not implemented: fix latency.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(not config.use_begintransfer, TB_FAILURE, "not implemented: begintransfer support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(not config.use_response_signal, TB_FAILURE, "not implemented: response_signal support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+
+    -- synchronize to clk
+    wait until rising_edge(clk);
+
+    -- Handle host-write-request
+    for cycle in 1 to config.max_wait_cycles loop
+      check_value(avalon_mm_if.read = '0', TB_FAILURE, "expecting no read request.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+      if (avalon_mm_if.chipselect = '1' and avalon_mm_if.write = '1') then
+        log(config.id_for_bfm, "write was active after " & to_string(cycle) & " clock cycles", scope, msg_id_panel);
+        exit;
+
+      else
+        wait until rising_edge(clk);
+      end if;
+
+      if cycle = config.max_wait_cycles then
+        v_timeout := true;
+      end if;
+    end loop;
+
+    v_normalized_addr := avalon_mm_if.address;
+    addr_value        := v_normalized_addr(addr_value'length - 1 downto 0);
+    v_normalized_data := avalon_mm_if.writedata;
+    data_value        := v_normalized_data(data_value'length - 1 downto 0);
+
+    -- did we timeout?
+    if v_timeout then
+      alert(config.max_wait_cycles_severity, C_PROC_CALL & "=> Failed. Timeout waiting for readdatavalid during " & to_string(config.max_wait_cycles) & " clock cycles." & add_msg_delimiter(msg), scope);
+    end if;
+
+    log(config.id_for_bfm, C_PROC_CALL & "=> " & to_string(addr_value, HEX, SKIP_LEADING_0, INCL_RADIX) & ", " & to_string(data_value, HEX, SKIP_LEADING_0, INCL_RADIX) & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
+  end procedure avalon_mm_receive;
+
+  procedure avalon_mm_respond(
+    variable addr_value   : out std_logic_vector;
+    variable data_value   : in std_logic_vector;
+    constant msg          : in string;
+    signal   clk          : in std_logic;
+    signal   avalon_mm_if : inout t_avalon_mm_if;
+    constant scope        : in string                 := C_BFM_SCOPE;
+    constant msg_id_panel : in t_msg_id_panel         := shared_msg_id_panel;
+    constant config       : in t_avalon_mm_bfm_config := C_AVALON_MM_BFM_CONFIG_DEFAULT
+  ) is
+    constant C_PROC_NAME    : string                  := "avalon_mm_respond";
+    constant C_PROC_CALL    : string                  := "avalon_mm_respond(A:" & to_string(data_value, HEX, KEEP_LEADING_0, INCL_RADIX) & ")";
+
+    variable v_normalized_addr      : std_logic_vector(avalon_mm_if.address'length - 1 downto 0) := normalize_and_check(addr_value, avalon_mm_if.address, ALLOW_NARROWER, "addr", "avalon_mm_if.address", msg);
+    variable v_normalized_data      : std_logic_vector(avalon_mm_if.readdata'length - 1 downto 0) := normalize_and_check(data_value, avalon_mm_if.readdata, ALLOW_NARROWER, "data", "avalon_mm_if.readdata", msg);
+    variable v_timeout              : boolean := false;
+  begin
+
+    -- sanity check not implemented features
+    check_value(not config.use_waitrequest, TB_FAILURE, "not implemented: waitrequest support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(config.use_readdatavalid, TB_FAILURE, "not implemented: fix latency.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(not config.use_begintransfer, TB_FAILURE, "not implemented: begintransfer support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+    check_value(not config.use_response_signal, TB_FAILURE, "not implemented: response_signal support.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+
+    --synchronize to clk
+    wait until rising_edge(clk);
+
+    -- Handle read, write is not allowed
+    for cycle in 1 to config.max_wait_cycles loop
+      check_value(avalon_mm_if.write = '0', TB_FAILURE, "expecting no write request.", scope, ID_NEVER, msg_id_panel, C_PROC_NAME);
+      if (avalon_mm_if.chipselect = '1' and avalon_mm_if.read = '1') then
+        log(config.id_for_bfm, "read was active after " & to_string(cycle) & " clock cycles", scope, msg_id_panel);
+        exit;
+
+      else
+        wait until rising_edge(clk);
+      end if;
+
+      if cycle = config.max_wait_cycles then
+        v_timeout := true;
+      end if;
+    end loop;
+
+    -- retrieve address to be checked, assign data as readdata
+    v_normalized_addr          := avalon_mm_if.address;
+    addr_value                 := v_normalized_addr(addr_value'length - 1 downto 0);
+    avalon_mm_if.readdata      <= v_normalized_data;
+    avalon_mm_if.readdatavalid <= '1';
+
+    wait until rising_edge(clk);
+
+    -- did we timeout?
+    if v_timeout then
+      alert(config.max_wait_cycles_severity, C_PROC_CALL & "=> Failed. Timeout waiting for readdatavalid during " & to_string(config.max_wait_cycles) & " clock cycles." & add_msg_delimiter(msg), scope);
+    end if;
+
+    avalon_mm_if <= init_avalon_mm_if_signals(false, avalon_mm_if.address'length, avalon_mm_if.writedata'length);
+
+    log(config.id_for_bfm, C_PROC_CALL & "=> " & to_string(addr_value, HEX, SKIP_LEADING_0, INCL_RADIX) & " completed." & add_msg_delimiter(msg), scope, msg_id_panel);
+  end procedure avalon_mm_respond;
 
 end package body avalon_mm_bfm_pkg;

--- a/bitvis_vip_avalon_mm/src/avalon_mm_bfm_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/avalon_mm_bfm_pkg.vhd
@@ -285,12 +285,12 @@ package body avalon_mm_bfm_pkg is
     if is_host then
       -- BFM to DUT signals
       v_result.reset         := '0';
-      v_result.address       := (v_result.address'range => '0');
+      v_result.address       := (v_result.address'range => 'U');
       v_result.begintransfer := '0';
       v_result.byte_enable   := (v_result.byte_enable'range => '1');
       v_result.chipselect    := '0';
       v_result.write         := '0';
-      v_result.writedata     := (v_result.writedata'range => '0');
+      v_result.writedata     := (v_result.writedata'range => 'U');
       v_result.read          := '0';
       v_result.lock          := lock_value;
 
@@ -313,8 +313,8 @@ package body avalon_mm_bfm_pkg is
       v_result.lock          := 'Z';
 
       -- BFM to DUT signals
-      v_result.readdata      := (v_result.readdata'range => '0');
-      v_result.response      := (v_result.response'range => '0');
+      v_result.readdata      := (v_result.readdata'range => 'U');
+      v_result.response      := (v_result.response'range => 'U');
       v_result.waitrequest   := '0';
       v_result.readdatavalid := '0';
       v_result.irq           := '0';

--- a/bitvis_vip_avalon_mm/src/avalon_mm_vvc.vhd
+++ b/bitvis_vip_avalon_mm/src/avalon_mm_vvc.vhd
@@ -39,6 +39,8 @@ use work.vvc_sb_support_pkg.all;
 --=================================================================================================
 entity avalon_mm_vvc is
   generic(
+    -- When true: This VVC is an Avalon-MM host, when false: This VVC is an Avalon-MM agent.
+    GC_VVC_IS_HOST                           : boolean;
     GC_ADDR_WIDTH                            : integer range 1 to C_VVC_CMD_ADDR_MAX_LENGTH := 8; -- Avalon MM address bus
     GC_DATA_WIDTH                            : integer range 1 to C_VVC_CMD_DATA_MAX_LENGTH := 32; -- Avalon MM data bus
     GC_INSTANCE_IDX                          : natural                                      := 1; -- Instance index for this AVALON_MM_VVCT instance
@@ -51,15 +53,15 @@ entity avalon_mm_vvc is
     GC_RESULT_QUEUE_COUNT_THRESHOLD_SEVERITY : t_alert_level                                := C_RESULT_QUEUE_COUNT_THRESHOLD_SEVERITY
   );
   port(
-    clk                     : in    std_logic;
-    avalon_mm_vvc_master_if : inout t_avalon_mm_if := init_avalon_mm_if_signals(GC_ADDR_WIDTH, GC_DATA_WIDTH)
+    clk              : in    std_logic;
+    avalon_mm_vvc_if : inout t_avalon_mm_if := init_avalon_mm_if_signals(GC_VVC_IS_HOST, GC_ADDR_WIDTH, GC_DATA_WIDTH)
   );
 begin
   -- Check the interface widths to assure that the interface was correctly set up
-  assert (avalon_mm_vvc_master_if.address'length = GC_ADDR_WIDTH) report "avalon_mm_vvc_master_if.address'length /= GC_ADDR_WIDTH" severity failure;
-  assert (avalon_mm_vvc_master_if.writedata'length = GC_DATA_WIDTH) report "avalon_mm_vvc_master_if.writedata'length /= GC_DATA_WIDTH" severity failure;
-  assert (avalon_mm_vvc_master_if.readdata'length = GC_DATA_WIDTH) report "avalon_mm_vvc_master_if.readdata'length /= GC_DATA_WIDTH" severity failure;
-  assert (avalon_mm_vvc_master_if.byte_enable'length = GC_DATA_WIDTH / 8) report "avalon_mm_vvc_master_if.byte_enable'length /= GC_DATA_WIDTH/8" severity failure;
+  assert (avalon_mm_vvc_if.address'length = GC_ADDR_WIDTH) report "avalon_mm_vvc_if.address'length /= GC_ADDR_WIDTH" severity failure;
+  assert (avalon_mm_vvc_if.writedata'length = GC_DATA_WIDTH) report "avalon_mm_vvc_if.writedata'length /= GC_DATA_WIDTH" severity failure;
+  assert (avalon_mm_vvc_if.readdata'length = GC_DATA_WIDTH) report "avalon_mm_vvc_if.readdata'length /= GC_DATA_WIDTH" severity failure;
+  assert (avalon_mm_vvc_if.byte_enable'length = GC_DATA_WIDTH / 8) report "avalon_mm_vvc_if.byte_enable'length /= GC_DATA_WIDTH/8" severity failure;
 end entity avalon_mm_vvc;
 
 --=================================================================================================
@@ -227,7 +229,7 @@ begin
   p_cmd_executor : process is
     constant C_EXECUTOR_ID                           : natural                                            := 0;
     variable v_cmd                                   : t_vvc_cmd_record;
-    variable v_read_data                             : t_vvc_result; -- See vvc_cmd_pkg
+    variable v_result                                : t_vvc_result; -- See vvc_cmd_pkg
     variable v_timestamp_start_of_current_bfm_access : time                                               := 0 ns;
     variable v_timestamp_start_of_last_bfm_access    : time                                               := 0 ns;
     variable v_timestamp_end_of_last_bfm_access      : time                                               := 0 ns;
@@ -274,7 +276,7 @@ begin
 
       -- Check if command is a BFM access
       v_prev_command_was_bfm_access := v_command_is_bfm_access; -- save for insert_bfm_delay
-      if v_cmd.operation = WRITE or v_cmd.operation = READ or v_cmd.operation = CHECK or v_cmd.operation = RESET then
+      if v_cmd.operation = WRITE or v_cmd.operation = READ or v_cmd.operation = RECEIVE or v_cmd.operation = RESPOND or v_cmd.operation = CHECK or v_cmd.operation = RESET then
         v_command_is_bfm_access := true;
       else
         v_command_is_bfm_access := false;
@@ -299,170 +301,280 @@ begin
         -- VVC dedicated operations
         --===================================
         when WRITE =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
 
-          -- Normalise address and data
-          v_normalised_addr                                              := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_write() called with too wide address. " & v_cmd.msg);
-          v_normalised_data                                              := normalize_and_check(v_cmd.data, v_normalised_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalised_data", "avalon_mm_write() called with too wide data. " & v_cmd.msg);
-          if (v_cmd.byte_enable = (0 to v_cmd.byte_enable'length - 1 => '1')) then
-            v_normalised_byte_ena := (others => '1');
-          else
-            v_normalised_byte_ena := normalize_and_check(v_cmd.byte_enable, v_normalised_byte_ena, ALLOW_WIDER_NARROWER, "v_cmd.byte_enable", "v_normalised_byte_ena", "avalon_mm_write() called with too wide byte_enable. " & v_cmd.msg);
-          end if;
-          transaction_info.data(GC_DATA_WIDTH - 1 downto 0)              := v_normalised_data;
-          transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0)              := v_normalised_addr;
-          transaction_info.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0) := v_cmd.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0);
-
-          -- Call the corresponding procedure in the BFM package.
-          avalon_mm_write(addr_value   => v_normalised_addr,
-                          data_value   => v_normalised_data,
-                          msg          => format_msg(v_cmd),
-                          clk          => clk,
-                          avalon_mm_if => avalon_mm_vvc_master_if,
-                          byte_enable  => v_cmd.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0),
-                          scope        => C_SCOPE,
-                          msg_id_panel => v_msg_id_panel,
-                          config       => vvc_config.bfm_config);
-
-          -- Update vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
-
-        when READ =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
-
-          -- Normalise address
-          v_normalised_addr := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_read() called with too wide address. " & v_cmd.msg);
-
-          transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0) := v_normalised_addr;
-
-          -- Call the corresponding procedure in the BFM package.
-          if vvc_config.use_read_pipeline then
-            -- Stall until response command queue is no longer full
-            while command_response_queue.get_count(VOID) > vvc_config.num_pipeline_stages loop
-              wait for vvc_config.bfm_config.clock_period;
-            end loop;
-            avalon_mm_read_request(addr_value   => v_normalised_addr,
-                                   msg          => format_msg(v_cmd),
-                                   clk          => clk,
-                                   avalon_mm_if => avalon_mm_vvc_master_if,
-                                   scope        => C_SCOPE,
-                                   msg_id_panel => v_msg_id_panel,
-                                   config       => vvc_config.bfm_config);
-            work.td_vvc_entity_support_pkg.put_command_on_queue(v_cmd, command_response_queue, vvc_status, response_queue_is_increasing);
-
-          else
-
-            avalon_mm_read(addr_value   => v_normalised_addr,
-                           data_value   => v_read_data(GC_DATA_WIDTH - 1 downto 0),
-                           msg          => format_msg(v_cmd),
-                           clk          => clk,
-                           avalon_mm_if => avalon_mm_vvc_master_if,
-                           scope        => C_SCOPE,
-                           msg_id_panel => v_msg_id_panel,
-                           config       => vvc_config.bfm_config);
-
-            -- Request SB check result
-            if v_cmd.data_routing = TO_SB then
-              -- call SB check_received
-              avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, pad_avalon_mm_sb(v_read_data(GC_DATA_WIDTH - 1 downto 0)));
+            -- Normalise address and data
+            v_normalised_addr                                              := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_write() called with too wide address. " & v_cmd.msg);
+            v_normalised_data                                              := normalize_and_check(v_cmd.data, v_normalised_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalised_data", "avalon_mm_write() called with too wide data. " & v_cmd.msg);
+            if (v_cmd.byte_enable = (0 to v_cmd.byte_enable'length - 1 => '1')) then
+              v_normalised_byte_ena := (others => '1');
             else
-              -- Store the result
-              work.td_vvc_entity_support_pkg.store_result(result_queue => result_queue,
-                                                          cmd_idx      => v_cmd.cmd_idx,
-                                                          result       => v_read_data);
+              v_normalised_byte_ena := normalize_and_check(v_cmd.byte_enable, v_normalised_byte_ena, ALLOW_WIDER_NARROWER, "v_cmd.byte_enable", "v_normalised_byte_ena", "avalon_mm_write() called with too wide byte_enable. " & v_cmd.msg);
             end if;
+            transaction_info.data(GC_DATA_WIDTH - 1 downto 0)              := v_normalised_data;
+            transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0)              := v_normalised_addr;
+            transaction_info.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0) := v_cmd.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0);
 
-            -- Update vvc transaction info
-            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_read_data, COMPLETED, C_SCOPE);
-          end if;
-
-        when CHECK =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
-
-          -- Normalise address
-          v_normalised_addr := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_check() called with too wide address. " & v_cmd.msg);
-          v_normalised_data := normalize_and_check(v_cmd.data, v_normalised_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalised_data", "avalon_mm_check() called with too wide data. " & v_cmd.msg);
-
-          transaction_info.data(GC_DATA_WIDTH - 1 downto 0) := v_normalised_data;
-          transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0) := v_normalised_addr;
-          -- Call the corresponding procedure in the BFM package.
-          if vvc_config.use_read_pipeline then
-            -- Wait until response command queue is no longer full
-            while command_response_queue.get_count(VOID) > vvc_config.num_pipeline_stages loop
-              wait for vvc_config.bfm_config.clock_period;
-            end loop;
-
-            avalon_mm_read_request(addr_value    => v_normalised_addr,
-                                   msg           => format_msg(v_cmd),
-                                   clk           => clk,
-                                   avalon_mm_if  => avalon_mm_vvc_master_if,
-                                   scope         => C_SCOPE,
-                                   msg_id_panel  => v_msg_id_panel,
-                                   config        => vvc_config.bfm_config,
-                                   ext_proc_call => "avalon_mm_check(A:" & to_string(v_normalised_addr, HEX, KEEP_LEADING_0, INCL_RADIX) & ", " & to_string(v_normalised_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")"
-                                  );
-            work.td_vvc_entity_support_pkg.put_command_on_queue(v_cmd, command_response_queue, vvc_status, response_queue_is_increasing);
-          else
-            avalon_mm_check(addr_value   => v_normalised_addr,
-                            data_exp     => v_normalised_data,
-                            msg          => format_msg(v_cmd),
-                            clk          => clk,
-                            avalon_mm_if => avalon_mm_vvc_master_if,
-                            alert_level  => v_cmd.alert_level,
-                            scope        => C_SCOPE,
-                            msg_id_panel => v_msg_id_panel,
-                            config       => vvc_config.bfm_config);
+            -- Call the corresponding procedure in the BFM package.
+            avalon_mm_write(addr_value => v_normalised_addr,
+                         data_value    => v_normalised_data,
+                         msg           => format_msg(v_cmd),
+                         clk           => clk,
+                         avalon_mm_if  => avalon_mm_vvc_if,
+                         byte_enable   => v_cmd.byte_enable((GC_DATA_WIDTH / 8) - 1 downto 0),
+                         scope         => C_SCOPE,
+                         msg_id_panel  => v_msg_id_panel,
+                         config        => vvc_config.bfm_config);
 
             -- Update vvc transaction info
             set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
           end if;
 
-        when RESET =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+        when READ =>
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
 
-          -- Call the corresponding procedure in the BFM package.
-          avalon_mm_reset(clk            => clk,
-                          avalon_mm_if   => avalon_mm_vvc_master_if,
-                          num_rst_cycles => v_cmd.gen_integer_array(0),
+            -- Normalise address
+            v_normalised_addr := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_read() called with too wide address. " & v_cmd.msg);
+
+            transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0) := v_normalised_addr;
+
+            -- Call the corresponding procedure in the BFM package.
+            if vvc_config.use_read_pipeline then
+              -- Stall until response command queue is no longer full
+              while command_response_queue.get_count(VOID) > vvc_config.num_pipeline_stages loop
+                wait for vvc_config.bfm_config.clock_period;
+              end loop;
+              avalon_mm_read_request(addr_value   => v_normalised_addr,
+                                     msg          => format_msg(v_cmd),
+                                     clk          => clk,
+                                     avalon_mm_if => avalon_mm_vvc_if,
+                                     scope        => C_SCOPE,
+                                     msg_id_panel => v_msg_id_panel,
+                                     config       => vvc_config.bfm_config);
+              work.td_vvc_entity_support_pkg.put_command_on_queue(v_cmd, command_response_queue, vvc_status, response_queue_is_increasing);
+
+            else
+
+              -- scoreboard needs proper init
+              v_result := (others => (others => '0'));
+
+              avalon_mm_read(addr_value   => v_normalised_addr,
+                             data_value   => v_result.data(GC_DATA_WIDTH - 1 downto 0),
+                             msg          => format_msg(v_cmd),
+                             clk          => clk,
+                             avalon_mm_if => avalon_mm_vvc_if,
+                             scope        => C_SCOPE,
+                             msg_id_panel => v_msg_id_panel,
+                             config       => vvc_config.bfm_config);
+
+              -- Request SB check result
+              if v_cmd.data_routing = TO_SB then
+                -- call SB check_received
+                avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, v_result);
+              else
+                -- Store the result
+                work.td_vvc_entity_support_pkg.store_result(result_queue => result_queue,
+                                                            cmd_idx      => v_cmd.cmd_idx,
+                                                            result       => v_result);
+              end if;
+
+              -- Update vvc transaction info
+              set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_result, COMPLETED, C_SCOPE);
+            end if;
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
+          end if;
+
+        when RECEIVE =>
+          -- agent-receive is the counter part of host-write. so far it retrieves address and data, other host
+          -- controlled signals are not checked (like byteenable).
+          if not GC_VVC_IS_HOST then
+            -- sanity checks
+            check_value(not vvc_config.use_read_pipeline, TB_ERROR, "not implemented: read pipeline for agent vvc.", C_SCOPE, ID_NEVER, v_msg_id_panel);
+
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+
+            -- scoreboard needs proper init
+            v_result := (others => (others => '0'));
+
+            avalon_mm_receive(addr_value => v_result.addr(GC_ADDR_WIDTH - 1 downto 0),
+                          data_value     => v_result.data(GC_DATA_WIDTH - 1 downto 0),
                           msg            => format_msg(v_cmd),
+                          clk            => clk,
+                          avalon_mm_if   => avalon_mm_vvc_if,
                           scope          => C_SCOPE,
                           msg_id_panel   => v_msg_id_panel,
                           config         => vvc_config.bfm_config);
 
-          -- Update vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+            -- Request SB check result
+            if v_cmd.data_routing = TO_SB then
+              -- call SB check_received
+              avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, v_result);
+            else
+              -- Store the result
+              work.td_vvc_entity_support_pkg.store_result(result_queue => result_queue,
+                                                          cmd_idx      => v_cmd.cmd_idx,
+                                                          result       => v_result);
+            end if;
+
+            -- Update vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_result, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for agent VVC", C_SCOPE);
+          end if;
+
+        when RESPOND =>
+          -- agent-respond is the counter part of host-read. so far it retrieves address and replies requested readdata
+          -- using readdatavalid. other host controlled signals are not checked (like byteenable).
+          if not GC_VVC_IS_HOST then
+            -- sanity checks
+            check_value(not vvc_config.use_read_pipeline, TB_ERROR, "not implemented: read pipeline for agent vvc.", C_SCOPE, ID_NEVER, v_msg_id_panel);
+
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+
+            -- Normalise data
+            v_normalised_data := normalize_and_check(v_cmd.data, v_normalised_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalised_data", "avalon_mm_respond() called with too wide data. " & v_cmd.msg);
+
+            transaction_info.data(GC_DATA_WIDTH - 1 downto 0) := v_normalised_data;
+
+            -- scoreboard needs proper init
+            v_result := (others => (others => '0'));
+
+            avalon_mm_respond(addr_value => v_result.addr(GC_ADDR_WIDTH - 1 downto 0),
+                           data_value    => v_normalised_data,
+                           msg           => format_msg(v_cmd),
+                           clk           => clk,
+                           avalon_mm_if  => avalon_mm_vvc_if,
+                           scope         => C_SCOPE,
+                           msg_id_panel  => v_msg_id_panel,
+                           config        => vvc_config.bfm_config);
+
+            -- Request SB check result
+            if v_cmd.data_routing = TO_SB then
+              -- call SB check_received
+              avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, v_result);
+            else
+              -- Store the result
+              work.td_vvc_entity_support_pkg.store_result(result_queue => result_queue,
+                                                          cmd_idx      => v_cmd.cmd_idx,
+                                                          result       => v_result);
+            end if;
+
+            -- Update vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_result, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for agent VVC", C_SCOPE);
+          end if;
+
+        when CHECK =>
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+
+            -- Normalise address
+            v_normalised_addr := normalize_and_check(v_cmd.addr, v_normalised_addr, ALLOW_WIDER_NARROWER, "v_cmd.addr", "v_normalised_addr", "avalon_mm_check() called with too wide address. " & v_cmd.msg);
+            v_normalised_data := normalize_and_check(v_cmd.data, v_normalised_data, ALLOW_WIDER_NARROWER, "v_cmd.data", "v_normalised_data", "avalon_mm_check() called with too wide data. " & v_cmd.msg);
+
+            transaction_info.data(GC_DATA_WIDTH - 1 downto 0) := v_normalised_data;
+            transaction_info.addr(GC_ADDR_WIDTH - 1 downto 0) := v_normalised_addr;
+            -- Call the corresponding procedure in the BFM package.
+            if vvc_config.use_read_pipeline then
+              -- Wait until response command queue is no longer full
+              while command_response_queue.get_count(VOID) > vvc_config.num_pipeline_stages loop
+                wait for vvc_config.bfm_config.clock_period;
+              end loop;
+
+              avalon_mm_read_request(addr_value    => v_normalised_addr,
+                                     msg           => format_msg(v_cmd),
+                                     clk           => clk,
+                                     avalon_mm_if  => avalon_mm_vvc_if,
+                                     scope         => C_SCOPE,
+                                     msg_id_panel  => v_msg_id_panel,
+                                     config        => vvc_config.bfm_config,
+                                     ext_proc_call => "avalon_mm_check(A:" & to_string(v_normalised_addr, HEX, KEEP_LEADING_0, INCL_RADIX) & ", " & to_string(v_normalised_data, HEX, KEEP_LEADING_0, INCL_RADIX) & ")"
+                                    );
+              work.td_vvc_entity_support_pkg.put_command_on_queue(v_cmd, command_response_queue, vvc_status, response_queue_is_increasing);
+            else
+              avalon_mm_check(addr_value   => v_normalised_addr,
+                              data_exp     => v_normalised_data,
+                              msg          => format_msg(v_cmd),
+                              clk          => clk,
+                              avalon_mm_if => avalon_mm_vvc_if,
+                              alert_level  => v_cmd.alert_level,
+                              scope        => C_SCOPE,
+                              msg_id_panel => v_msg_id_panel,
+                              config       => vvc_config.bfm_config);
+
+              -- Update vvc transaction info
+              set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+            end if;
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
+          end if;
+
+        when RESET =>
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+
+            -- Call the corresponding procedure in the BFM package.
+            avalon_mm_reset(clk            => clk,
+                            avalon_mm_if   => avalon_mm_vvc_if,
+                            num_rst_cycles => v_cmd.gen_integer_array(0),
+                            msg            => format_msg(v_cmd),
+                            scope          => C_SCOPE,
+                            msg_id_panel   => v_msg_id_panel,
+                            config         => vvc_config.bfm_config);
+
+            -- Update vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
+          end if;
 
         when LOCK =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
 
-          -- Call the corresponding procedure in the BFM package.
-          avalon_mm_lock(avalon_mm_if => avalon_mm_vvc_master_if,
-                         msg          => format_msg(v_cmd),
-                         scope        => C_SCOPE,
-                         msg_id_panel => v_msg_id_panel,
-                         config       => vvc_config.bfm_config);
-
-          -- Update vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
-
-        when UNLOCK =>
-          -- Set vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
-
-          -- Call the corresponding procedure in the BFM package.
-          avalon_mm_unlock(avalon_mm_if => avalon_mm_vvc_master_if,
+            -- Call the corresponding procedure in the BFM package.
+            avalon_mm_lock(avalon_mm_if => avalon_mm_vvc_if,
                            msg          => format_msg(v_cmd),
                            scope        => C_SCOPE,
                            msg_id_panel => v_msg_id_panel,
                            config       => vvc_config.bfm_config);
 
-          -- Update vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+            -- Update vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
+          end if;
+
+        when UNLOCK =>
+          if GC_VVC_IS_HOST then
+            -- Set vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_SCOPE);
+
+            -- Call the corresponding procedure in the BFM package.
+            avalon_mm_unlock(avalon_mm_if => avalon_mm_vvc_if,
+                             msg          => format_msg(v_cmd),
+                             scope        => C_SCOPE,
+                             msg_id_panel => v_msg_id_panel,
+                             config       => vvc_config.bfm_config);
+
+            -- Update vvc transaction info
+            set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, COMPLETED, C_SCOPE);
+          else
+            alert(TB_ERROR, "Sanity check: Method call only makes sense for host VVC", C_SCOPE);
+          end if;
 
         -- UVVM common operations
         --===================================
@@ -517,13 +629,13 @@ begin
   -- Read response command execution.
   -- - READ (and CHECK) data received from the slave after the command executor has issued an
   --   read request (or check).
-  -- - Note the use of propagation delayed avalon_mm_vv_master_if signal
+  -- - Note the use of propagation delayed avalon_mm_vvc_if signal
   --===============================================================================================
   p_read_response : process is
     constant C_EXECUTOR_ID          : natural                                      := 1;
     variable v_cmd                  : t_vvc_cmd_record;
     variable v_msg_id_panel         : t_msg_id_panel;
-    variable v_read_data            : t_vvc_result; -- See vvc_cmd_pkg
+    variable v_result               : t_vvc_result; -- See vvc_cmd_pkg
     variable v_normalised_addr      : unsigned(GC_ADDR_WIDTH - 1 downto 0)         := (others => '0');
     variable v_normalised_data      : std_logic_vector(GC_DATA_WIDTH - 1 downto 0) := (others => '0');
     constant C_READ_RESP_SCOPE      : string                                       := get_scope_for_log(C_VVC_NAME & "_RR", GC_INSTANCE_IDX);
@@ -561,27 +673,28 @@ begin
           set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, vvc_config, IN_PROGRESS, C_READ_RESP_SCOPE);
 
           -- Initiate read response
+          v_result := (others => (others => '0'));
           avalon_mm_read_response(addr_value   => v_normalised_addr,
-                                  data_value   => v_read_data(GC_DATA_WIDTH - 1 downto 0),
+                                  data_value   => v_result.data(GC_DATA_WIDTH - 1 downto 0),
                                   msg          => format_msg(v_cmd),
                                   clk          => clk,
-                                  avalon_mm_if => avalon_mm_vvc_master_if,
+                                  avalon_mm_if => avalon_mm_vvc_if,
                                   scope        => C_READ_RESP_SCOPE,
                                   msg_id_panel => v_msg_id_panel,
                                   config       => vvc_config.bfm_config);
           -- Request SB check result
           if v_cmd.data_routing = TO_SB then
             -- call SB check_received
-            avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, pad_avalon_mm_sb(v_read_data(GC_DATA_WIDTH - 1 downto 0)));
+            avalon_mm_vvc_sb.check_received(GC_INSTANCE_IDX, v_result);
           else
             -- Store the result
             work.td_vvc_entity_support_pkg.store_result(result_queue => result_queue,
                                                         cmd_idx      => v_cmd.cmd_idx,
-                                                        result       => v_read_data);
+                                                        result       => v_result);
           end if;
 
           -- Update vvc transaction info
-          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_read_data, COMPLETED, C_READ_RESP_SCOPE);
+          set_global_vvc_transaction_info(vvc_transaction_info_trigger, vvc_transaction_info, v_cmd, v_result, COMPLETED, C_READ_RESP_SCOPE);
 
         when CHECK =>
           -- Set vvc transaction info
@@ -592,7 +705,7 @@ begin
                                    data_exp     => v_normalised_data,
                                    msg          => format_msg(v_cmd),
                                    clk          => clk,
-                                   avalon_mm_if => avalon_mm_vvc_master_if,
+                                   avalon_mm_if => avalon_mm_vvc_if,
                                    alert_level  => v_cmd.alert_level,
                                    scope        => C_READ_RESP_SCOPE,
                                    msg_id_panel => v_msg_id_panel,
@@ -657,17 +770,17 @@ begin
         end loop;
       end if;
 
-      wait on avalon_mm_vvc_master_if.readdata, avalon_mm_vvc_master_if.response, avalon_mm_vvc_master_if.waitrequest, avalon_mm_vvc_master_if.readdatavalid, avalon_mm_vvc_master_if.irq, global_trigger_vvc_activity_register;
+      wait on avalon_mm_vvc_if.readdata, avalon_mm_vvc_if.response, avalon_mm_vvc_if.waitrequest, avalon_mm_vvc_if.readdatavalid, avalon_mm_vvc_if.irq, global_trigger_vvc_activity_register;
 
       -- Check the changes on the DUT outputs only when the vvc is inactive
       if shared_vvc_activity_register.priv_get_vvc_activity(entry_num_in_vvc_activity_register) = INACTIVE then
         -- Skip checking the changes if the readdatavalid signal goes low within one clock period after the VVC becomes inactive
-        if not (falling_edge(avalon_mm_vvc_master_if.readdatavalid) and global_trigger_vvc_activity_register'last_event < clock_period) then
-          check_unwanted_activity(avalon_mm_vvc_master_if.readdatavalid, vvc_config.unwanted_activity_severity, "readdatavalid", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_master_if.readdata, vvc_config.unwanted_activity_severity, "readdata", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_master_if.response, vvc_config.unwanted_activity_severity, "response", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_master_if.waitrequest, vvc_config.unwanted_activity_severity, "waitrequest", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_master_if.irq, vvc_config.unwanted_activity_severity, "irq", C_SCOPE);
+        if not (falling_edge(avalon_mm_vvc_if.readdatavalid) and global_trigger_vvc_activity_register'last_event < clock_period) then
+          check_unwanted_activity(avalon_mm_vvc_if.readdatavalid, vvc_config.unwanted_activity_severity, "readdatavalid", C_SCOPE);
+          check_unwanted_activity(avalon_mm_vvc_if.readdata, vvc_config.unwanted_activity_severity, "readdata", C_SCOPE);
+          check_unwanted_activity(avalon_mm_vvc_if.response, vvc_config.unwanted_activity_severity, "response", C_SCOPE);
+          check_unwanted_activity(avalon_mm_vvc_if.waitrequest, vvc_config.unwanted_activity_severity, "waitrequest", C_SCOPE);
+          check_unwanted_activity(avalon_mm_vvc_if.irq, vvc_config.unwanted_activity_severity, "irq", C_SCOPE);
         end if;
       end if;
     end loop;

--- a/bitvis_vip_avalon_mm/src/avalon_mm_vvc.vhd
+++ b/bitvis_vip_avalon_mm/src/avalon_mm_vvc.vhd
@@ -770,17 +770,20 @@ begin
         end loop;
       end if;
 
-      wait on avalon_mm_vvc_if.readdata, avalon_mm_vvc_if.response, avalon_mm_vvc_if.waitrequest, avalon_mm_vvc_if.readdatavalid, avalon_mm_vvc_if.irq, global_trigger_vvc_activity_register;
+      wait on avalon_mm_vvc_if.read, avalon_mm_vvc_if.write, avalon_mm_vvc_if.chipselect, avalon_mm_vvc_if.readdatavalid, avalon_mm_vvc_if.irq, global_trigger_vvc_activity_register;
 
-      -- Check the changes on the DUT outputs only when the vvc is inactive
+      -- Check the control signal changes only when the vvc is inactive
       if shared_vvc_activity_register.priv_get_vvc_activity(entry_num_in_vvc_activity_register) = INACTIVE then
         -- Skip checking the changes if the readdatavalid signal goes low within one clock period after the VVC becomes inactive
         if not (falling_edge(avalon_mm_vvc_if.readdatavalid) and global_trigger_vvc_activity_register'last_event < clock_period) then
           check_unwanted_activity(avalon_mm_vvc_if.readdatavalid, vvc_config.unwanted_activity_severity, "readdatavalid", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_if.readdata, vvc_config.unwanted_activity_severity, "readdata", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_if.response, vvc_config.unwanted_activity_severity, "response", C_SCOPE);
-          check_unwanted_activity(avalon_mm_vvc_if.waitrequest, vvc_config.unwanted_activity_severity, "waitrequest", C_SCOPE);
           check_unwanted_activity(avalon_mm_vvc_if.irq, vvc_config.unwanted_activity_severity, "irq", C_SCOPE);
+          check_unwanted_activity(avalon_mm_vvc_if.chipselect, vvc_config.unwanted_activity_severity, "chipselect", C_SCOPE);
+          -- read and write are qualified by chicpselect, agents may be selected all the time
+          if (avalon_mm_vvc_if.chipselect = '1') then
+            check_unwanted_activity(avalon_mm_vvc_if.read, vvc_config.unwanted_activity_severity, "read", C_SCOPE);
+            check_unwanted_activity(avalon_mm_vvc_if.write, vvc_config.unwanted_activity_severity, "write", C_SCOPE);
+          end if;
         end if;
       end if;
     end loop;

--- a/bitvis_vip_avalon_mm/src/transaction_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/transaction_pkg.vhd
@@ -42,6 +42,9 @@ package transaction_pkg is
     INSERT_DELAY,
     TERMINATE_CURRENT_COMMAND,
     -- VVC local
+    -- agent side
+    RECEIVE, RESPOND,
+    -- host side
     WRITE, READ, CHECK, RESET, LOCK, UNLOCK
   );
 

--- a/bitvis_vip_avalon_mm/src/vvc_cmd_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/vvc_cmd_pkg.vhd
@@ -99,7 +99,10 @@ package vvc_cmd_pkg is
   -- - t_vvc_result includes the return value of the procedure in the BFM.
   --   It can also be defined as a record if multiple values shall be transported from the BFM
   --===============================================================================================
-  subtype t_vvc_result is std_logic_vector(C_VVC_CMD_DATA_MAX_LENGTH - 1 downto 0);
+  type t_vvc_result is record
+    addr : std_logic_vector(C_VVC_CMD_ADDR_MAX_LENGTH - 1 downto 0);
+    data : std_logic_vector(C_VVC_CMD_DATA_MAX_LENGTH - 1 downto 0);
+  end record;
 
   type t_vvc_result_queue_element is record
     cmd_idx : natural;                  -- from UVVM handshake mechanism
@@ -126,4 +129,37 @@ package vvc_cmd_pkg is
   --===============================================================================================
   shared variable shared_vvc_last_received_cmd_idx : t_last_received_cmd_idx(t_channel'left to t_channel'right, 0 to C_VVC_MAX_INSTANCE_NUM - 1) := (others => (others => -1));
 
+  --==========================================================================================
+  -- Procedures
+  --==========================================================================================
+  function to_string(
+    result : t_vvc_result
+  ) return string;
+
+  function vvc_result_match(
+    received_result : t_vvc_result;
+    expected_result : t_vvc_result
+  ) return boolean;
+
 end package vvc_cmd_pkg;
+
+package body vvc_cmd_pkg is
+
+  -- Custom to_string overload needed when result is of a record type, ref: vvc_cmd_pkg.vhd in bitvis_vip_rgmii
+  function to_string(
+    result : t_vvc_result
+  ) return string is
+  begin
+    return "addr: " & to_string(result.addr, HEX_BIN_IF_INVALID) & ", data: " & to_string(result.data, HEX_BIN_IF_INVALID);
+  end function;
+
+  function vvc_result_match(
+    received_result : t_vvc_result;
+    expected_result : t_vvc_result
+  ) return boolean is
+  begin
+    return std_match(received_result.addr, expected_result.addr) and
+           std_match(received_result.data, expected_result.data);
+  end function;
+
+end package body;

--- a/bitvis_vip_avalon_mm/src/vvc_methods_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/vvc_methods_pkg.vhd
@@ -211,6 +211,25 @@ package vvc_methods_pkg is
     constant parent_msg_id_panel : in t_msg_id_panel := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
   );
 
+  procedure avalon_mm_receive(
+    signal   VVCT                : inout t_vvc_target_record;
+    constant vvc_instance_idx    : in integer;
+    constant data_routing        : in t_data_routing;
+    constant msg                 : in string;
+    constant scope               : in string         := C_VVC_CMD_SCOPE_DEFAULT;
+    constant parent_msg_id_panel : in t_msg_id_panel := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+  );
+
+  procedure avalon_mm_respond(
+    signal   VVCT                : inout t_vvc_target_record;
+    constant vvc_instance_idx    : in integer;
+    constant data                : in std_logic_vector;
+    constant data_routing        : in t_data_routing;
+    constant msg                 : in string;
+    constant scope               : in string         := C_VVC_CMD_SCOPE_DEFAULT;
+    constant parent_msg_id_panel : in t_msg_id_panel := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+  );
+
   --==============================================================================
   -- Transactino info methods
   --==============================================================================
@@ -452,6 +471,59 @@ package body vvc_methods_pkg is
     send_command_to_vvc(VVCT, std.env.resolution_limit, scope, v_msg_id_panel);
   end procedure;
 
+  procedure avalon_mm_receive(
+    signal   VVCT                : inout t_vvc_target_record;
+    constant vvc_instance_idx    : in integer;
+    constant data_routing        : in t_data_routing;
+    constant msg                 : in string;
+    constant scope               : in string         := C_VVC_CMD_SCOPE_DEFAULT;
+    constant parent_msg_id_panel : in t_msg_id_panel := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+  ) is
+    constant C_PROC_NAME : string := "avalon_mm_receive";
+    constant C_PROC_CALL       : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) -- First part common for all
+                                           & ", " & to_upper(to_string(data_routing)) & ")";
+    variable v_msg_id_panel    : t_msg_id_panel                                            := shared_msg_id_panel;
+  begin
+    -- Create command by setting common global 'VVCT' signal record and dedicated VVC 'shared_vvc_cmd' record
+    -- locking semaphore in set_general_target_and_command_fields to gain exclusive right to VVCT and shared_vvc_cmd
+    -- semaphore gets unlocked in await_cmd_from_sequencer of the targeted VVC
+    set_general_target_and_command_fields(VVCT, vvc_instance_idx, C_PROC_CALL, msg, QUEUED, RECEIVE);
+    shared_vvc_cmd.data_routing        := data_routing;
+    shared_vvc_cmd.parent_msg_id_panel := parent_msg_id_panel;
+    if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
+      v_msg_id_panel := parent_msg_id_panel;
+    end if;
+    send_command_to_vvc(VVCT, std.env.resolution_limit, scope, v_msg_id_panel);
+  end procedure;
+
+  procedure avalon_mm_respond(
+    signal   VVCT                : inout t_vvc_target_record;
+    constant vvc_instance_idx    : in integer;
+    constant data                : in std_logic_vector;
+    constant data_routing        : in t_data_routing;
+    constant msg                 : in string;
+    constant scope               : in string         := C_VVC_CMD_SCOPE_DEFAULT;
+    constant parent_msg_id_panel : in t_msg_id_panel := C_UNUSED_MSG_ID_PANEL -- Only intended for usage by parent HVVCs
+  ) is
+    constant C_PROC_NAME : string := "avalon_mm_respond";
+    constant C_PROC_CALL       : string := C_PROC_NAME & "(" & to_string(VVCT, vvc_instance_idx) -- First part common for all
+                                           & ", " & to_string(data, HEX, KEEP_LEADING_0, INCL_RADIX) & ", " & to_upper(to_string(data_routing)) & ")";
+    variable v_normalised_data : std_logic_vector(shared_vvc_cmd.data'length - 1 downto 0) := normalize_and_check(data, shared_vvc_cmd.data, ALLOW_WIDER_NARROWER, "data", "shared_vvc_cmd.data", C_PROC_CALL & " called with too wide data." & add_msg_delimiter(msg));
+    variable v_msg_id_panel    : t_msg_id_panel                                            := shared_msg_id_panel;
+  begin
+    -- Create command by setting common global 'VVCT' signal record and dedicated VVC 'shared_vvc_cmd' record
+    -- locking semaphore in set_general_target_and_command_fields to gain exclusive right to VVCT and shared_vvc_cmd
+    -- semaphore gets unlocked in await_cmd_from_sequencer of the targeted VVC
+    set_general_target_and_command_fields(VVCT, vvc_instance_idx, C_PROC_CALL, msg, QUEUED, RESPOND);
+    shared_vvc_cmd.data                := v_normalised_data;
+    shared_vvc_cmd.data_routing        := data_routing;
+    shared_vvc_cmd.parent_msg_id_panel := parent_msg_id_panel;
+    if parent_msg_id_panel /= C_UNUSED_MSG_ID_PANEL then
+      v_msg_id_panel := parent_msg_id_panel;
+    end if;
+    send_command_to_vvc(VVCT, std.env.resolution_limit, scope, v_msg_id_panel);
+  end procedure;
+
   --==============================================================================
   -- Transaction info methods
   --==============================================================================
@@ -474,7 +546,7 @@ package body vvc_methods_pkg is
         vvc_transaction_info_group.bt.transaction_status := transaction_status;
         gen_pulse(vvc_transaction_info_trigger, 0 ns, "pulsing global vvc transaction info trigger", scope, ID_NEVER);
 
-      when READ | CHECK =>
+      when READ | CHECK | RECEIVE | RESPOND =>
         vvc_transaction_info_group.st.operation          := vvc_cmd.operation;
         vvc_transaction_info_group.st.addr               := vvc_cmd.addr;
         vvc_transaction_info_group.st.data               := vvc_cmd.data;
@@ -500,7 +572,18 @@ package body vvc_methods_pkg is
   begin
     case vvc_cmd.operation is
       when READ =>
-        vvc_transaction_info_group.st.data               := vvc_result;
+        vvc_transaction_info_group.st.data               := vvc_result.data;
+        vvc_transaction_info_group.st.transaction_status := transaction_status;
+        gen_pulse(vvc_transaction_info_trigger, 0 ns, "pulsing global vvc transaction info trigger", scope, ID_NEVER);
+
+      when RECEIVE =>
+        vvc_transaction_info_group.st.addr               := unsigned(vvc_result.addr);
+        vvc_transaction_info_group.st.data               := vvc_result.data;
+        vvc_transaction_info_group.st.transaction_status := transaction_status;
+        gen_pulse(vvc_transaction_info_trigger, 0 ns, "pulsing global vvc transaction info trigger", scope, ID_NEVER);
+
+      when RESPOND =>
+        vvc_transaction_info_group.st.addr               := unsigned(vvc_result.addr);
         vvc_transaction_info_group.st.transaction_status := transaction_status;
         gen_pulse(vvc_transaction_info_trigger, 0 ns, "pulsing global vvc transaction info trigger", scope, ID_NEVER);
 
@@ -519,7 +602,7 @@ package body vvc_methods_pkg is
       when WRITE | RESET | LOCK | UNLOCK =>
         vvc_transaction_info_group.bt := C_BASE_TRANSACTION_SET_DEFAULT;
 
-      when READ | CHECK =>
+      when READ | CHECK | RECEIVE | RESPOND =>
         vvc_transaction_info_group.st := C_SUB_TRANSACTION_SET_DEFAULT;
 
       when others =>

--- a/bitvis_vip_avalon_mm/src/vvc_sb_pkg.vhd
+++ b/bitvis_vip_avalon_mm/src/vvc_sb_pkg.vhd
@@ -25,11 +25,14 @@ library bitvis_vip_scoreboard;
 
 use work.transaction_pkg.all;
 
+library bitvis_vip_avalon_mm;
+use bitvis_vip_avalon_mm.vvc_cmd_pkg;
+
 package vvc_sb_pkg is new bitvis_vip_scoreboard.generic_sb_pkg
   generic map(
-    t_element         => std_logic_vector(C_VVC_CMD_DATA_MAX_LENGTH - 1 downto 0),
-    element_match     => std_match,
-    to_string_element => to_string);
+    t_element         => vvc_cmd_pkg.t_vvc_result,
+    element_match     => vvc_cmd_pkg.vvc_result_match,
+    to_string_element => vvc_cmd_pkg.to_string);
 
 --==========================================================================================
 --  vvc_sb_support_pkg
@@ -41,23 +44,60 @@ use ieee.numeric_std.all;
 library bitvis_vip_scoreboard;
 use bitvis_vip_scoreboard.generic_sb_support_pkg.all;
 
+library bitvis_vip_avalon_mm;
+use bitvis_vip_avalon_mm.vvc_cmd_pkg.t_vvc_result;
+
 use work.transaction_pkg.all;
 
 package vvc_sb_support_pkg is
-  -- The data parameter used in the scoreboard procedures needs to have the same length as
+  -- The data parameter used in the scoreboard procedures needs to have the same length/type as
   -- the t_element defined in the VVC's built-in scoreboard, since even though it is a generic
   -- type, it constrained during elaboration time.
   -- This function is used to pad the data without having to know the exact length of t_element.
-  function pad_avalon_mm_sb(
+  function pad_avalon_mm_addr_sb(
+    constant addr : in std_logic_vector
+  ) return t_vvc_result;
+
+  function pad_avalon_mm_data_sb(
     constant data : in std_logic_vector
-  ) return std_logic_vector;
+  ) return t_vvc_result;
+
+  function pad_avalon_mm_addr_and_data_sb(
+    constant addr : in std_logic_vector;
+    constant data : in std_logic_vector
+  ) return t_vvc_result;
+
 end package vvc_sb_support_pkg;
 
 package body vvc_sb_support_pkg is
-  function pad_avalon_mm_sb(
-    constant data : in std_logic_vector
-  ) return std_logic_vector is
+
+  function pad_avalon_mm_addr_sb(
+    constant addr : in std_logic_vector
+  ) return t_vvc_result is
+    variable v_result : t_vvc_result := (others => (others => '0'));
   begin
-    return pad_sb_slv(data, C_VVC_CMD_DATA_MAX_LENGTH);
-  end function pad_avalon_mm_sb;
+    v_result.addr := pad_sb_slv(addr, C_VVC_CMD_ADDR_MAX_LENGTH);
+    return v_result;
+  end function pad_avalon_mm_addr_sb;
+
+  function pad_avalon_mm_data_sb(
+    constant data : in std_logic_vector
+  ) return t_vvc_result is
+    variable v_result : t_vvc_result := (others => (others => '0'));
+  begin
+    v_result.data := pad_sb_slv(data, C_VVC_CMD_DATA_MAX_LENGTH);
+    return v_result;
+  end function pad_avalon_mm_data_sb;
+
+  function pad_avalon_mm_addr_and_data_sb(
+    constant addr : in std_logic_vector;
+    constant data : in std_logic_vector
+  ) return t_vvc_result is
+    variable v_result : t_vvc_result := (others => (others => '0'));
+  begin
+    v_result.addr := pad_sb_slv(addr, C_VVC_CMD_ADDR_MAX_LENGTH);
+    v_result.data := pad_sb_slv(data, C_VVC_CMD_DATA_MAX_LENGTH);
+    return v_result;
+  end function pad_avalon_mm_addr_and_data_sb;
+
 end package body vvc_sb_support_pkg;

--- a/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_pipeline_tb.vhd
+++ b/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_pipeline_tb.vhd
@@ -26,6 +26,7 @@ use uvvm_vvc_framework.ti_vvc_framework_support_pkg.all;
 
 library bitvis_vip_avalon_mm;
 context bitvis_vip_avalon_mm.vvc_context;
+use bitvis_vip_avalon_mm.vvc_cmd_pkg.all;
 
 --hdlregression:tb
 -- Test case entity
@@ -129,13 +130,14 @@ begin
   g_not_delta_delayed_vvc_clk : if not GC_DELTA_DELAYED_VVC_CLK generate
     i1_avalon_mm_vvc : entity work.avalon_mm_vvc
       generic map(
+        GC_VVC_IS_HOST  => true,
         GC_ADDR_WIDTH   => C_ADDR_WIDTH,
         GC_DATA_WIDTH   => C_DATA_WIDTH,
         GC_INSTANCE_IDX => 1
       )
       port map(
         clk                     => clk, -- Not delta delayed. Exact same clk as DUT
-        avalon_mm_vvc_master_if => avalon_mm_if_1
+        avalon_mm_vvc_if => avalon_mm_if_1
       );
   end generate;
 
@@ -148,13 +150,14 @@ begin
   g_delta_delayed_vvc_clk : if GC_DELTA_DELAYED_VVC_CLK generate
     i1_avalon_mm_vvc : entity work.avalon_mm_vvc
       generic map(
+        GC_VVC_IS_HOST  => true,
         GC_ADDR_WIDTH   => C_ADDR_WIDTH,
         GC_DATA_WIDTH   => C_DATA_WIDTH,
         GC_INSTANCE_IDX => 1
       )
       port map(
         clk                     => clk_delta_delayed_d1, -- Delta delayed wrt DUT, which can affect sampling of signals
-        avalon_mm_vvc_master_if => avalon_mm_if_1
+        avalon_mm_vvc_if => avalon_mm_if_1
       );
   end generate;
 
@@ -182,7 +185,7 @@ begin
     variable v_cmd_idx       : natural;
     variable v_data_int      : natural;
     variable v_prev_data_int : natural;
-    variable v_data          : std_logic_vector(1023 downto 0);
+    variable v_result        : t_vvc_result;
     variable v_is_ok         : boolean;
 
   begin
@@ -327,8 +330,8 @@ begin
       avalon_mm_read(AVALON_MM_VVCT, 1, x"0", "Reading i=" & to_string(i));
       v_cmd_idx       := get_last_received_cmd_idx(AVALON_MM_VVCT, 1); -- for last read
       await_completion(AVALON_MM_VVCT, 1, 100 us, "Wait for _read to finish");
-      fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_data, "Fetching read-result");
-      v_data_int      := to_integer(unsigned(v_data(29 downto 0)));
+      fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_result, "Fetching read-result");
+      v_data_int      := to_integer(unsigned(v_result.data(29 downto 0)));
       check_value_in_range(v_data_int, v_prev_data_int + 5, (2 ** 30) - 1, ERROR, "checking that read data has increased (i.e. not sampling the same readdata twice), Reading i=" & to_string(i));
       -- For Next iteration
       v_prev_data_int := v_data_int;
@@ -347,9 +350,9 @@ begin
     v_cmd_idx := get_last_received_cmd_idx(AVALON_MM_VVCT, 1); -- Retrieve the command index for the read
     avalon_mm_unlock(AVALON_MM_VVCT, 1, "Send a new command to VVC which executes faster than the read to increase the last_cmd_idx_executed");
     await_completion(AVALON_MM_VVCT, 1, v_cmd_idx, 100 us, "Wait for read to finish");
-    fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_data, v_is_ok, "Fetching read-result");
+    fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_result, v_is_ok, "Fetching read-result");
     check_value(v_is_ok, ERROR, "Readback OK via fetch_result()");
-    check_value(v_data(31 downto 0), x"10100011", ERROR, "Readback data via fetch_result()");
+    check_value(v_result.data(31 downto 0), x"10100011", ERROR, "Readback data via fetch_result()");
 
     -----------------------------------------------------------------------------
     -- Ending the simulation

--- a/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_tb.vhd
+++ b/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_tb.vhd
@@ -27,6 +27,7 @@ use uvvm_vvc_framework.ti_vvc_framework_support_pkg.all;
 library bitvis_vip_avalon_mm;
 context bitvis_vip_avalon_mm.vvc_context;
 use bitvis_vip_avalon_mm.vvc_sb_support_pkg.all;
+use bitvis_vip_avalon_mm.vvc_cmd_pkg.all;
 
 --hdlregression:tb
 -- Test case entity
@@ -59,7 +60,7 @@ begin
     -- Sequencer constants and variables
     constant C_SCOPE       : string                       := C_TB_SCOPE_DEFAULT;
     variable v_cmd_idx     : natural;
-    variable v_data        : std_logic_vector(C_VVC_CMD_DATA_MAX_LENGTH - 1 downto 0);
+    variable v_result      : t_vvc_result;
     variable v_data_8      : std_logic_vector(7 downto 0) := (others => '0');
     variable v_is_ok       : boolean;
     variable v_timestamp   : time;
@@ -199,12 +200,12 @@ begin
     v_data_8 := x"10";
 
     avalon_mm_write(AVALON_MM_VVCT, 1, "0", v_data_8, "Write to Avalon MM 1");
-    avalon_mm_vvc_sb.add_expected(1, pad_avalon_mm_sb(v_data_8));
+    avalon_mm_vvc_sb.add_expected(1, pad_avalon_mm_data_sb(v_data_8));
     avalon_mm_read(AVALON_MM_VVCT, 1, "0", TO_SB, "Reading without expected timeout using SB");
     await_completion(AVALON_MM_VVCT, 1, 10000 ns, "Wait for avalon_mm_read to finish");
 
     avalon_mm_write(AVALON_MM_VVCT, 2, "0", v_data_8, "Write to Avalon MM 2");
-    avalon_mm_vvc_sb.add_expected(2, pad_avalon_mm_sb(v_data_8));
+    avalon_mm_vvc_sb.add_expected(2, pad_avalon_mm_data_sb(v_data_8));
     avalon_mm_read(AVALON_MM_VVCT, 2, "0", TO_SB, "Reading without expected timeout using SB");
     await_completion(AVALON_MM_VVCT, 2, 10000 ns, "Wait for avalon_mm_read to finish");
 
@@ -215,9 +216,9 @@ begin
     avalon_mm_read(AVALON_MM_VVCT, 1, "0", "Reading without expected timeout");
     v_cmd_idx := get_last_received_cmd_idx(AVALON_MM_VVCT, 1); -- for last read
     await_completion(AVALON_MM_VVCT, 1, v_cmd_idx, 100 ns, "Wait for sbi_read to finish");
-    fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_data, v_is_ok, "Fetching read-result");
+    fetch_result(AVALON_MM_VVCT, 1, v_cmd_idx, v_result, v_is_ok, "Fetching read-result");
     check_value(v_is_ok, ERROR, "Readback OK via fetch_result()");
-    check_value(v_data(31 downto 0), x"10", ERROR, "Readback data via fetch_result()");
+    check_value(v_result.data(31 downto 0), x"10", ERROR, "Readback data via fetch_result()");
 
     log("Do another read - should timeout");
     shared_avalon_mm_vvc_config(1).bfm_config.max_wait_cycles_severity := WARNING;

--- a/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_th.vhd
+++ b/bitvis_vip_avalon_mm/tb/maintenance_tb/avalon_mm_vvc_th.vhd
@@ -142,24 +142,26 @@ begin
   -----------------------------
   i1_avalon_mm_vvc : entity work.avalon_mm_vvc
     generic map(
+      GC_VVC_IS_HOST  => true,
       GC_ADDR_WIDTH   => C_ADDR_WIDTH,
       GC_DATA_WIDTH   => C_DATA_WIDTH,
       GC_INSTANCE_IDX => 1
     )
     port map(
       clk                     => clk,
-      avalon_mm_vvc_master_if => avalon_mm_if_1
+      avalon_mm_vvc_if => avalon_mm_if_1
     );
 
   i2_avalon_mm_vvc : entity work.avalon_mm_vvc
     generic map(
+      GC_VVC_IS_HOST  => true,
       GC_ADDR_WIDTH   => C_ADDR_WIDTH,
       GC_DATA_WIDTH   => C_DATA_WIDTH,
       GC_INSTANCE_IDX => 2
     )
     port map(
       clk                     => clk,
-      avalon_mm_vvc_master_if => avalon_mm_if_2
+      avalon_mm_vvc_if => avalon_mm_if_2
     );
 
   p_clk : clock_generator(clk, GC_CLK_PERIOD);


### PR DESCRIPTION
# Agent VVC

Currently, the Avalon-MM VIP offers a host (master) VVC. What do you think about this approach of including an agent VVC similar the way it was implemented in the Avalon-ST VIP? The generic 'GC_VVC_IS_HOST' sanity-checks the role + two new VVC and BFM methods handle it. Agent-respond handles host-read requests and agent-receive handles host-write requests.

# Unwanted activity detection

Monitor control signals only, as other signals have to be qualified anyway and therefore don't matter.

# Default signal state

'uninitalized' seems more apropriate, '0' was most likely required for the previous unwanted-activity-detection?
